### PR TITLE
Export spoiler log without building ROM

### DIFF
--- a/fMain.Designer.cs
+++ b/fMain.Designer.cs
@@ -744,7 +744,7 @@
             this.cN64.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.cN64.Checked = true;
             this.cN64.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cN64.Enabled = false;
+            this.cN64.Enabled = true;
             this.cN64.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.cN64.ForeColor = System.Drawing.Color.Black;
             this.cN64.Location = new System.Drawing.Point(117, 71);
@@ -753,6 +753,7 @@
             this.cN64.TabIndex = 10;
             this.cN64.Text = "N64 ROM";
             this.cN64.UseVisualStyleBackColor = false;
+            this.cN64.CheckedChanged += cN64_CheckedChanged;
             // 
             // lOutput
             // 

--- a/fMain.cs
+++ b/fMain.cs
@@ -393,6 +393,10 @@ namespace MMRando
 
         private void cVC_CheckedChanged(object sender, EventArgs e)
         {
+            cN64.Enabled = !cVC.Checked;
+            cN64.Checked = cVC.Checked || cN64.Checked;
+
+            Output_ROM = cVC.Checked;
             Output_VC = cVC.Checked;
         }
 
@@ -447,6 +451,9 @@ namespace MMRando
         private void cN64_CheckedChanged(object sender, EventArgs e)
         {
             Output_ROM = cN64.Checked;
+            cVC.Enabled = cN64.Checked;
+
+            bopen.Enabled = Output_ROM;
         }
     }
 

--- a/fMain.cs
+++ b/fMain.cs
@@ -9,7 +9,7 @@ namespace MMRando
 
     public partial class mmrMain : Form
     {
-
+        bool Output_ROM = true;
         bool Updating = false;
         bool Output_VC = false;
         string SettingOld = "";
@@ -133,7 +133,7 @@ namespace MMRando
                 cGossip.Enabled = false;
                 cAdditional.Enabled = false;
                 cUserItems.Enabled = false;
-            } 
+            }
             else
             {
                 cMixSongs.Enabled = true;
@@ -235,19 +235,19 @@ namespace MMRando
                 MessageBox.Show($"Error randomizing logic: {ex.Message}\r\n\r\nPlease try a different seed", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
-            if (!File.Exists(tROMName.Text))
+            if (Output_ROM && !File.Exists(tROMName.Text))
             {
                 MessageBox.Show("Input ROM not selected or doesn't exist, cannot generate output.",
                     "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 return;
             }
-            if (saveROM.ShowDialog() != DialogResult.OK)
+            if (Output_ROM && saveROM.ShowDialog() != DialogResult.OK)
             {
                 MessageBox.Show("No output selected; ROM will not be saved.",
                     "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 return;
             }
-            if (saveROM.FileName == "")
+            if (Output_ROM && saveROM.FileName == "")
             {
                 MessageBox.Show("Output file not selected.",
                     "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -262,12 +262,30 @@ namespace MMRando
                     return;
                 };
             };
-            if (!ValidateROM(tROMName.Text))
+            if (Output_ROM && !ValidateROM(tROMName.Text))
             {
                 MessageBox.Show("Cannot verify input ROM is Majora's Mask (U).",
                     "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
+
+            if (!Output_ROM && !Output_VC)
+            {
+                if (cSpoiler.Checked)
+                {
+                    WriteSpoilerLog();
+
+                    MessageBox.Show("Successfully built output spoiler log!",
+                        "Success", MessageBoxButtons.OK, MessageBoxIcon.None);
+                }
+                else
+                {
+                    MessageBox.Show("No output specified!",
+                        "Warning", MessageBoxButtons.OK, MessageBoxIcon.None);
+                }
+                return;
+            }
+
             MakeROM(tROMName.Text, saveROM.FileName);
             MessageBox.Show("Successfully built output ROM!",
                 "Success", MessageBoxButtons.OK, MessageBoxIcon.None);
@@ -426,6 +444,10 @@ namespace MMRando
             ItemEditor.Show();
         }
 
+        private void cN64_CheckedChanged(object sender, EventArgs e)
+        {
+            Output_ROM = cN64.Checked;
+        }
     }
 
 }


### PR DESCRIPTION
Enabled toggling output ROM.

- Unchecking N64 ROM output allows you to check spoiler generation, and generate a spoiler log alone
- Disabling output n64 disables VC (as per now, VC requires ROM to be built)
- When randomizing without any output or spoiler log, displays warning "no output"

Related to #8 