### PR TITLE
Free hints option

### DIFF
--- a/Build.cs
+++ b/Build.cs
@@ -208,6 +208,13 @@ namespace MMRando
             }
         }
 
+        private void WriteUnlockHints()
+        {
+            int address = 0x00E0A810 + 0x378;
+            byte val = 0x00;
+            ROMFuncs.WriteToROM(address, val);
+        }
+
         private void WriteFreeItem(int Item)
         {
             ROMFuncs.WriteToROM(Items.ITEM_ADDRS[Item], Items.ITEM_VALUES[Item]);
@@ -310,6 +317,11 @@ namespace MMRando
             if (Settings.LogicMode == LogicMode.Vanilla)
             {
                 return;
+            }
+
+            if (Settings.UnlockGossipHints)
+            {
+                WriteUnlockHints();
             }
 
             if (Settings.EnableGossipHints)
@@ -473,7 +485,6 @@ namespace MMRando
             worker.ReportProgress(100, "Done!");
 
         }
-
     }
 
 }

--- a/Build.cs
+++ b/Build.cs
@@ -208,6 +208,9 @@ namespace MMRando
             }
         }
 
+        /// <summary>
+        /// Update the gossip stone actor to not check mask of truth
+        /// </summary>
         private void WriteFreeHints()
         {
             int address = 0x00E0A810 + 0x378;

--- a/Build.cs
+++ b/Build.cs
@@ -208,7 +208,7 @@ namespace MMRando
             }
         }
 
-        private void WriteUnlockHints()
+        private void WriteFreeHints()
         {
             int address = 0x00E0A810 + 0x378;
             byte val = 0x00;
@@ -319,9 +319,9 @@ namespace MMRando
                 return;
             }
 
-            if (Settings.UnlockGossipHints)
+            if (Settings.FreeHints)
             {
-                WriteUnlockHints();
+                WriteFreeHints();
             }
 
             if (Settings.EnableGossipHints)

--- a/Models/Settings.cs
+++ b/Models/Settings.cs
@@ -148,5 +148,10 @@ namespace MMRando.Models
         /// Replaces Tatl's colors
         /// </summary>
         public TatlColorSchema TatlColorSchema { get; set; }
+        
+        /// <summary>
+        /// Removes the need for Mask of Truth to read gossip stone hints
+        /// </summary>
+        public bool UnlockGossipHints { get; set; }
     }
 }

--- a/fAbout.Designer.cs
+++ b/fAbout.Designer.cs
@@ -36,9 +36,10 @@
             // 
             // lAboutText
             // 
-            this.lAboutText.Location = new System.Drawing.Point(27, 33);
+            this.lAboutText.Location = new System.Drawing.Point(36, 41);
+            this.lAboutText.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lAboutText.Name = "lAboutText";
-            this.lAboutText.Size = new System.Drawing.Size(308, 145);
+            this.lAboutText.Size = new System.Drawing.Size(411, 206);
             this.lAboutText.TabIndex = 0;
             this.lAboutText.Text = resources.GetString("lAboutText.Text");
             this.lAboutText.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -47,8 +48,9 @@
             // 
             this.lAboutTitle.Font = new System.Drawing.Font("Microsoft Sans Serif", 16F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lAboutTitle.Location = new System.Drawing.Point(0, 1);
+            this.lAboutTitle.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lAboutTitle.Name = "lAboutTitle";
-            this.lAboutTitle.Size = new System.Drawing.Size(359, 27);
+            this.lAboutTitle.Size = new System.Drawing.Size(479, 33);
             this.lAboutTitle.TabIndex = 1;
             this.lAboutTitle.Text = "Majora\'s Mask Randomizer";
             this.lAboutTitle.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -56,9 +58,10 @@
             // discordLinkLabel
             // 
             this.discordLinkLabel.AutoSize = true;
-            this.discordLinkLabel.Location = new System.Drawing.Point(108, 119);
+            this.discordLinkLabel.Location = new System.Drawing.Point(144, 146);
+            this.discordLinkLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.discordLinkLabel.Name = "discordLinkLabel";
-            this.discordLinkLabel.Size = new System.Drawing.Size(141, 13);
+            this.discordLinkLabel.Size = new System.Drawing.Size(179, 17);
             this.discordLinkLabel.TabIndex = 2;
             this.discordLinkLabel.TabStop = true;
             this.discordLinkLabel.Text = "https://discord.gg/8qbreUM";
@@ -67,14 +70,15 @@
             // 
             // fAbout
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(359, 183);
+            this.ClientSize = new System.Drawing.Size(479, 254);
             this.Controls.Add(this.discordLinkLabel);
             this.Controls.Add(this.lAboutTitle);
             this.Controls.Add(this.lAboutText);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.MaximizeBox = false;
             this.Name = "fAbout";
             this.Text = "About";

--- a/fAbout.resx
+++ b/fAbout.resx
@@ -125,8 +125,9 @@ Original by DeathBasket
 Maintained by the Majora's Mask Randomizer Community Discord.
 
 
-Thanks to: Jimmie1717 and KiKe
-currently developed by:
+Thanks to: Jimmie1717, KiKe and kskjer
+
+Currently developed by:
 ZoeyZolotova, Kjelli, ZMarotrix</value>
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />

--- a/fMain.Designer.cs
+++ b/fMain.Designer.cs
@@ -952,6 +952,7 @@ namespace MMRando
             this.cFreeHints.TabIndex = 15;
             this.cFreeHints.Text = "Free Hints";
             this.cFreeHints.UseVisualStyleBackColor = false;
+            this.cFreeHints.CheckedChanged += cFreeHints_CheckedChanged;
             // 
             // MainRandomizerForm
             // 

--- a/fMain.cs
+++ b/fMain.cs
@@ -372,7 +372,7 @@ namespace MMRando
         {
             if (Settings.LogicMode == LogicMode.Vanilla)
             {
-                //cUnlockHints.Enabled = false; TODO
+                cFreeHints.Enabled = false;
                 cMixSongs.Enabled = false;
                 cSoS.Enabled = false;
                 cDChests.Enabled = false;
@@ -386,7 +386,7 @@ namespace MMRando
             }
             else
             {
-                //cUnlockHints.Enabled = true; TODO
+                cFreeHints.Enabled = true;
                 cMixSongs.Enabled = true;
                 cSoS.Enabled = true;
                 cDChests.Enabled = true;
@@ -496,7 +496,6 @@ namespace MMRando
 
             bTunic.BackColor = Color.FromArgb(0x1E, 0x69, 0x1B);
 
-            Settings.UnlockGossipHints = true;
             Settings.GenerateSpoilerLog = true;
             Settings.ExcludeSongOfSoaring = true;
             Settings.EnableGossipHints = true;
@@ -516,7 +515,7 @@ namespace MMRando
         {
             int[] O = new int[3];
 
-            if (Settings.UnlockGossipHints) { O[0] += 16384; };
+            if (Settings.FreeHints) { O[0] += 16384; };
             if (Settings.UseCustomItemList) { O[0] += 8192; };
             if (Settings.AddOther) { O[0] += 4096; };
             if (Settings.EnableGossipHints) { O[0] += 2048; };
@@ -579,7 +578,7 @@ namespace MMRando
             int Combos = (int)Base36.Decode(O[1]);
             int ColourAndMisc = (int)Base36.Decode(O[2]);
 
-            Settings.UnlockGossipHints = (Checks & 16384) > 0;
+            Settings.FreeHints = (Checks & 16384) > 0;
             Settings.UseCustomItemList = (Checks & 8192) > 0;
             Settings.AddOther = (Checks & 4096) > 0;
             Settings.EnableGossipHints = (Checks & 2048) > 0;
@@ -595,7 +594,7 @@ namespace MMRando
             Settings.ShortenCutscenes = (Checks & 2) > 0;
             Settings.QuickTextEnabled = (Checks & 1) > 0;
 
-            //cUnlockHints.Checked = Settings.UnlockGossipHints; TODO
+            cFreeHints.Checked = Settings.FreeHints;
             cUserItems.Checked = Settings.UseCustomItemList;
             cAdditional.Checked = Settings.AddOther;
             cGossip.Checked = Settings.EnableGossipHints;

--- a/fMain.cs
+++ b/fMain.cs
@@ -295,6 +295,10 @@ namespace MMRando
         {
             UpdateSingleSetting(() => Settings.TatlColorSchema = (TatlColorSchema)cTatl.SelectedIndex);
         }
+        private void cFreeHints_CheckedChanged(object sender, EventArgs e)
+        {
+            UpdateSingleSetting(() => Settings.FreeHints = cFreeHints.Checked);
+        }
 
         private void cMode_SelectedIndexChanged(object sender, EventArgs e)
         {

--- a/fMain.cs
+++ b/fMain.cs
@@ -364,9 +364,7 @@ namespace MMRando
         {
             ItemEditor.Show();
         }
-
-
-
+        
         /// <summary>
         /// Checks for settings that invalidate others, and disable the checkboxes for them.
         /// </summary>
@@ -374,6 +372,7 @@ namespace MMRando
         {
             if (Settings.LogicMode == LogicMode.Vanilla)
             {
+                //cUnlockHints.Enabled = false; TODO
                 cMixSongs.Enabled = false;
                 cSoS.Enabled = false;
                 cDChests.Enabled = false;
@@ -387,6 +386,7 @@ namespace MMRando
             }
             else
             {
+                //cUnlockHints.Enabled = true; TODO
                 cMixSongs.Enabled = true;
                 cSoS.Enabled = true;
                 cDChests.Enabled = true;
@@ -496,6 +496,7 @@ namespace MMRando
 
             bTunic.BackColor = Color.FromArgb(0x1E, 0x69, 0x1B);
 
+            Settings.UnlockGossipHints = true;
             Settings.GenerateSpoilerLog = true;
             Settings.ExcludeSongOfSoaring = true;
             Settings.EnableGossipHints = true;
@@ -515,6 +516,7 @@ namespace MMRando
         {
             int[] O = new int[3];
 
+            if (Settings.UnlockGossipHints) { O[0] += 16384; };
             if (Settings.UseCustomItemList) { O[0] += 8192; };
             if (Settings.AddOther) { O[0] += 4096; };
             if (Settings.EnableGossipHints) { O[0] += 2048; };
@@ -577,6 +579,7 @@ namespace MMRando
             int Combos = (int)Base36.Decode(O[1]);
             int ColourAndMisc = (int)Base36.Decode(O[2]);
 
+            Settings.UnlockGossipHints = (Checks & 16384) > 0;
             Settings.UseCustomItemList = (Checks & 8192) > 0;
             Settings.AddOther = (Checks & 4096) > 0;
             Settings.EnableGossipHints = (Checks & 2048) > 0;
@@ -592,6 +595,7 @@ namespace MMRando
             Settings.ShortenCutscenes = (Checks & 2) > 0;
             Settings.QuickTextEnabled = (Checks & 1) > 0;
 
+            //cUnlockHints.Checked = Settings.UnlockGossipHints; TODO
             cUserItems.Checked = Settings.UseCustomItemList;
             cAdditional.Checked = Settings.AddOther;
             cGossip.Checked = Settings.EnableGossipHints;


### PR DESCRIPTION
Added checkbox with option to remove the need for mask of truth in order to read gossip stone hints. Located under Comfort / Cosmetics.

Thanks to @kskjer for discovering the location in the rom files to manipulate.
Thanks to @Zmarotrix for letting me stay out of designer files :joy:.