### PR TITLE
Add Version, Setting String, and Seed to top of spoiler log

### DIFF
--- a/Shuffle.cs
+++ b/Shuffle.cs
@@ -484,6 +484,9 @@ namespace MMRando
 
             StreamWriter LogFile = new StreamWriter(Path.Combine(directory, filename));
 
+            LogFile.WriteLine("Version: " + AssemblyVersion.Substring(26));
+            LogFile.WriteLine("Settings String: \"" + settingsString + "\"");
+            LogFile.WriteLine("Seed: \"" + Settings.Seed + "\"\n");
 
             if (Settings.RandomizeDungeonEntrances)
             {


### PR DESCRIPTION
Adds the version for the randomizer, the settings string, and the seed for the playthrough at the top of the Spoiler Log.