### PR TITLE
New gimmick: Blast mask cooldown modifier

### DIFF
--- a/Builder.cs
+++ b/Builder.cs
@@ -1,4 +1,7 @@
-﻿using MMRando.Constants;
+﻿using MMRando.Attributes;
+using MMRando.Constants;
+using MMRando.Extensions;
+using MMRando.GameObjects;
 using MMRando.Models;
 using MMRando.Models.Rom;
 using MMRando.Models.Settings;
@@ -10,9 +13,6 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using MMRando.GameObjects;
-using MMRando.Extensions;
-using MMRando.Attributes;
 using System.Text.RegularExpressions;
 
 namespace MMRando
@@ -245,7 +245,7 @@ namespace MMRando
                 ResourceUtils.ApplyHack(Values.ModsDirectory + "floor-" + floorType.ToString());
             }
 
-            if(_settings.ClockSpeed != ClockSpeed.Default)
+            if (_settings.ClockSpeed != ClockSpeed.Default)
             {
                 WriteClockSpeed(_settings.ClockSpeed);
             }
@@ -254,6 +254,42 @@ namespace MMRando
             {
                 WriteHideClock();
             }
+
+            if (_settings.BlastMaskCooldown != BlastMaskCooldown.Default)
+            {
+                WriteBlastMaskCooldown();
+            }
+        }
+
+        private void WriteBlastMaskCooldown()
+        {
+            ushort value;
+            switch (_settings.BlastMaskCooldown)
+            {
+                default:
+                case BlastMaskCooldown.Default:
+                    value = 0x136; // 310 frames 
+                    break;
+                case BlastMaskCooldown.Instant:
+                    value = 0x1; // 1 frame
+                    break;
+                case BlastMaskCooldown.VeryShort:
+                    value = 0x20; // 32 frames
+                    break;
+                case BlastMaskCooldown.Short:
+                    value = 0x80; // 128 frames
+                    break;
+                case BlastMaskCooldown.Long:
+                    value = 0x200; // 512 frames
+                    break;
+                case BlastMaskCooldown.VeryLong:
+                    value = 0x400; // 1024 frames
+                    break;
+            }
+
+            var codeFileAddress = 0x00CA7F00;
+            var offset = 0x002766;
+            ReadWriteUtils.WriteToROM(codeFileAddress + offset, value);
         }
 
         private void WriteHideClock()
@@ -306,7 +342,7 @@ namespace MMRando
             var hackAddressOffset = 0x8A674;
             var modificationOffset = 0x1B;
             ReadWriteUtils.WriteToROM(codeFileAddress + hackAddressOffset + modificationOffset, speed);
-            
+
             var invertedModifierOffsets = new List<int>
             {
                 0xB1B8E,
@@ -349,7 +385,7 @@ namespace MMRando
         {
             Dictionary<int, byte> startingItems = new Dictionary<int, byte>();
             PutOrCombine(startingItems, 0xC5CE72, 0x10); // add Song of Time
-            
+
             var itemList = items.ToList();
             itemList.Add(Item.StartingHeartContainer1);
             while (itemList.Count(item => item.Name() == "Piece of Heart") >= 4)
@@ -484,7 +520,7 @@ namespace MMRando
                     {
                         Id = (ushort)tingleText,
                         Header = null,
-                        Message = $"\u0002\u00C3{item1.Name() + " ", -22}\u0001{tingleShop.Prices[0], 2} Rupees\u0011\u0002{item2.Name() + " ", -22}\u0001{tingleShop.Prices[1], 2} Rupees\u0011\u0002No Thanks\u00BF"
+                        Message = $"\u0002\u00C3{item1.Name() + " ",-22}\u0001{tingleShop.Prices[0],2} Rupees\u0011\u0002{item2.Name() + " ",-22}\u0001{tingleShop.Prices[1],2} Rupees\u0011\u0002No Thanks\u00BF"
                     });
                 }
 

--- a/Forms/MainForm.Designer.cs
+++ b/Forms/MainForm.Designer.cs
@@ -53,6 +53,7 @@ namespace MMRando
             this.cEnemy = new System.Windows.Forms.CheckBox();
             this.cMixSongs = new System.Windows.Forms.CheckBox();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.cFairyRewards = new System.Windows.Forms.CheckBox();
             this.lCustomItemAmount = new System.Windows.Forms.Label();
             this.tCustomItemList = new System.Windows.Forms.TextBox();
             this.bItemListEditor = new System.Windows.Forms.Button();
@@ -133,7 +134,8 @@ namespace MMRando
             this.tpPatchSettings = new System.Windows.Forms.TabPage();
             this.tPatch = new System.Windows.Forms.TextBox();
             this.bLoadPatch = new System.Windows.Forms.Button();
-            this.cFairyRewards = new System.Windows.Forms.CheckBox();
+            this.label8 = new System.Windows.Forms.Label();
+            this.cBlastCooldown = new System.Windows.Forms.ComboBox();
             this.tSettings.SuspendLayout();
             this.tabROMSettings.SuspendLayout();
             this.groupBox1.SuspendLayout();
@@ -431,6 +433,21 @@ namespace MMRando
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Item Pool Options";
             // 
+            // cFairyRewards
+            // 
+            this.cFairyRewards.AutoSize = true;
+            this.cFairyRewards.BackColor = System.Drawing.Color.Transparent;
+            this.cFairyRewards.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.cFairyRewards.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.cFairyRewards.ForeColor = System.Drawing.Color.Black;
+            this.cFairyRewards.Location = new System.Drawing.Point(188, 53);
+            this.cFairyRewards.Name = "cFairyRewards";
+            this.cFairyRewards.Size = new System.Drawing.Size(122, 17);
+            this.cFairyRewards.TabIndex = 21;
+            this.cFairyRewards.Text = "Great Fairy Rewards";
+            this.cFairyRewards.UseVisualStyleBackColor = false;
+            this.cFairyRewards.CheckedChanged += new System.EventHandler(this.cFairyRewards_CheckedChanged);
+            // 
             // lCustomItemAmount
             // 
             this.lCustomItemAmount.AutoSize = true;
@@ -639,6 +656,8 @@ namespace MMRando
             // 
             // tabGimmick
             // 
+            this.tabGimmick.Controls.Add(this.cBlastCooldown);
+            this.tabGimmick.Controls.Add(this.label8);
             this.tabGimmick.Controls.Add(this.label7);
             this.tabGimmick.Controls.Add(this.cHideClock);
             this.tabGimmick.Controls.Add(this.label6);
@@ -663,7 +682,7 @@ namespace MMRando
             // 
             this.label7.AutoSize = true;
             this.label7.ForeColor = System.Drawing.SystemColors.ActiveBorder;
-            this.label7.Location = new System.Drawing.Point(13, 200);
+            this.label7.Location = new System.Drawing.Point(13, 228);
             this.label7.Name = "label7";
             this.label7.Size = new System.Drawing.Size(325, 13);
             this.label7.TabIndex = 18;
@@ -676,7 +695,7 @@ namespace MMRando
             this.cHideClock.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.cHideClock.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.cHideClock.ForeColor = System.Drawing.Color.Black;
-            this.cHideClock.Location = new System.Drawing.Point(55, 224);
+            this.cHideClock.Location = new System.Drawing.Point(55, 252);
             this.cHideClock.Name = "cHideClock";
             this.cHideClock.Size = new System.Drawing.Size(92, 17);
             this.cHideClock.TabIndex = 17;
@@ -1385,20 +1404,31 @@ namespace MMRando
             this.bLoadPatch.UseVisualStyleBackColor = true;
             this.bLoadPatch.Click += new System.EventHandler(this.BLoadPatch_Click);
             // 
-            // cFairyRewards
+            // label8
             // 
-            this.cFairyRewards.AutoSize = true;
-            this.cFairyRewards.BackColor = System.Drawing.Color.Transparent;
-            this.cFairyRewards.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.cFairyRewards.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.cFairyRewards.ForeColor = System.Drawing.Color.Black;
-            this.cFairyRewards.Location = new System.Drawing.Point(188, 53);
-            this.cFairyRewards.Name = "cFairyRewards";
-            this.cFairyRewards.Size = new System.Drawing.Size(122, 17);
-            this.cFairyRewards.TabIndex = 21;
-            this.cFairyRewards.Text = "Great Fairy Rewards";
-            this.cFairyRewards.UseVisualStyleBackColor = false;
-            this.cFairyRewards.CheckedChanged += new System.EventHandler(this.cFairyRewards_CheckedChanged);
+            this.label8.AutoSize = true;
+            this.label8.Location = new System.Drawing.Point(9, 205);
+            this.label8.Name = "label8";
+            this.label8.Size = new System.Drawing.Size(112, 13);
+            this.label8.TabIndex = 19;
+            this.label8.Text = "Blast Mask Cooldown:";
+            // 
+            // cBlastCooldown
+            // 
+            this.cBlastCooldown.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cBlastCooldown.FormattingEnabled = true;
+            this.cBlastCooldown.Items.AddRange(new object[] {
+            "Default",
+            "Instant",
+            "Very short",
+            "Short",
+            "Long",
+            "Very Long"});
+            this.cBlastCooldown.Location = new System.Drawing.Point(127, 203);
+            this.cBlastCooldown.Name = "cBlastCooldown";
+            this.cBlastCooldown.Size = new System.Drawing.Size(158, 21);
+            this.cBlastCooldown.TabIndex = 20;
+            this.cBlastCooldown.SelectedIndexChanged += new System.EventHandler(this.cBlastCooldown_SelectedIndexChanged);
             // 
             // MainForm
             // 
@@ -1554,6 +1584,8 @@ namespace MMRando
         private System.Windows.Forms.TextBox tCustomItemList;
         private System.Windows.Forms.Label lCustomItemAmount;
         private System.Windows.Forms.CheckBox cFairyRewards;
+        private System.Windows.Forms.ComboBox cBlastCooldown;
+        private System.Windows.Forms.Label label8;
     }
 }
 

--- a/Forms/MainForm.cs
+++ b/Forms/MainForm.cs
@@ -92,6 +92,7 @@ namespace MMRando
             TooltipBuilder.SetTooltip(cClockSpeed, "Modify the speed of time.");
             TooltipBuilder.SetTooltip(cHideClock, "Clock UI will be hidden.");
             TooltipBuilder.SetTooltip(cNoStartingItems, "You will not start with any randomized starting items.");
+            TooltipBuilder.SetTooltip(cBlastCooldown, "Adjust the cooldown timer after using the Blast Mask.");
 
             // Comforts/cosmetics
             TooltipBuilder.SetTooltip(cCutsc, "Enable shortened cutscenes.\n\nCertain cutscenes are skipped or otherwise shortened.\nDISCLAIMER: This may cause crashing in certain emulators.");
@@ -287,7 +288,7 @@ namespace MMRando
             cFairyRewards.Checked = _settings.AddFairyRewards;
             cClearHints.Checked = _settings.ClearHints;
             cHideClock.Checked = _settings.HideClock;
-            cClockSpeed.SelectedIndex = (int) _settings.ClockSpeed;
+            cClockSpeed.SelectedIndex = (int)_settings.ClockSpeed;
             cNoDowngrades.Checked = _settings.PreventDowngrades;
             cShopAppearance.Checked = _settings.UpdateShopAppearance;
             cNutChest.Checked = _settings.AddNutChest;
@@ -304,6 +305,7 @@ namespace MMRando
             cGravity.SelectedIndex = (int)_settings.MovementMode;
             cFloors.SelectedIndex = (int)_settings.FloorType;
             cGossipHints.SelectedIndex = (int)_settings.GossipHintStyle;
+            cBlastCooldown.SelectedIndex = (int)_settings.BlastMaskCooldown;
             bTunic.BackColor = _settings.TunicColor;
         }
 
@@ -370,7 +372,7 @@ namespace MMRando
             UpdateSingleSetting(() => _settings.GeneratePatch = cPatch.Checked);
         }
 
-        private void cHTMLLog_CheckedChanged(object sender,EventArgs e)
+        private void cHTMLLog_CheckedChanged(object sender, EventArgs e)
         {
             UpdateSingleSetting(() => _settings.GenerateHTMLLog = cHTMLLog.Checked);
         }
@@ -557,6 +559,12 @@ namespace MMRando
             UpdateSingleSetting(() => _settings.GossipHintStyle = (GossipHintStyle)cGossipHints.SelectedIndex);
         }
 
+
+        private void cBlastCooldown_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            UpdateSingleSetting(() => _settings.BlastMaskCooldown = (BlastMaskCooldown)cBlastCooldown.SelectedIndex);
+        }
+
         private void cVC_CheckedChanged(object sender, EventArgs e)
         {
             UpdateSingleSetting(() => _settings.OutputVC = cVC.Checked);
@@ -720,6 +728,7 @@ namespace MMRando
             cFloors.Enabled = v;
             cClockSpeed.Enabled = v;
             cGossipHints.Enabled = v;
+            cBlastCooldown.Enabled = v;
             cHideClock.Enabled = v;
             cGravity.Enabled = v;
             cLink.Enabled = v;
@@ -772,6 +781,7 @@ namespace MMRando
             cTatl.SelectedIndex = 0;
             cGossipHints.SelectedIndex = 0;
             cClockSpeed.SelectedIndex = 0;
+            cBlastCooldown.SelectedIndex = 0;
             cSpoiler.Checked = true;
             cSoS.Checked = true;
             cNoDowngrades.Checked = true;
@@ -842,7 +852,7 @@ namespace MMRando
                     MessageBox.Show($"Error randomizing logic: {ex.Message}{nl}{nl}Please try a different seed", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
-                
+
                 if (_settings.GenerateSpoilerLog
                     && _settings.LogicMode != LogicMode.Vanilla)
                 {
@@ -933,6 +943,7 @@ namespace MMRando
             cFloors.Enabled = v;
             cClockSpeed.Enabled = v;
             cHideClock.Enabled = v;
+            cBlastCooldown.Enabled = v;
 
 
             // Comfort/Cosmetics
@@ -958,5 +969,6 @@ namespace MMRando
                 tPatch.Text = null;
             }
         }
+
     }
 }

--- a/Majora's Mask Randomiser.csproj
+++ b/Majora's Mask Randomiser.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Models\RandomizedResult.cs" />
     <Compile Include="Models\Rom\MessageTable.cs" />
     <Compile Include="Models\Rom\Enemy.cs" />
+    <Compile Include="Models\Settings\BlastMaskCooldown.cs" />
     <Compile Include="Models\Settings\GossipHintStyle.cs" />
     <Compile Include="Models\Settings\ClockSpeedMode.cs" />
     <Compile Include="Models\Settings\SettingsObject.cs" />

--- a/Models/Settings/BlastMaskCooldown.cs
+++ b/Models/Settings/BlastMaskCooldown.cs
@@ -1,0 +1,12 @@
+﻿namespace MMRando.Models.Settings
+{
+    public enum BlastMaskCooldown
+    {
+        Default,
+        Instant,
+        VeryShort,
+        Short,
+        Long,
+        VeryLong
+    }
+}

--- a/Models/Settings/SettingsObject.cs
+++ b/Models/Settings/SettingsObject.cs
@@ -1,6 +1,4 @@
-﻿
-using MMRando.Constants;
-using MMRando.Utils;
+﻿using MMRando.Utils;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -216,6 +214,11 @@ namespace MMRando.Models.Settings
         /// </summary>
         public bool HideClock { get; set; }
 
+        /// <summary>
+        /// Increases or decreases the cooldown of using the blast mask
+        /// </summary>
+        public BlastMaskCooldown BlastMaskCooldown { get; set; }
+
         #endregion
 
         #region Comfort / Cosmetics
@@ -371,6 +374,7 @@ namespace MMRando.Models.Settings
 
             var clockSpeedIndex = (byte)(part4 & 0xFF);
             var gossipHintsIndex = (byte)((part4 & 0xFF00) >> 8);
+            var blastmaskCooldown = (byte)((part4 & 0xF0000) >> 16);
 
             DamageMode = (DamageMode)damageMultiplierIndex;
             DamageEffect = (DamageEffect)damageTypeIndex;
@@ -382,7 +386,7 @@ namespace MMRando.Models.Settings
             TunicColor = tunicColor;
             ClockSpeed = (ClockSpeed)clockSpeedIndex;
             GossipHintStyle = (GossipHintStyle)gossipHintsIndex;
-
+            BlastMaskCooldown = (BlastMaskCooldown)blastmaskCooldown;
         }
 
 
@@ -436,8 +440,9 @@ namespace MMRando.Models.Settings
                 | ((byte)FloorType << 24)
                     | ((byte)MovementMode << 28);
 
-            parts[3] = (byte) ClockSpeed
-                | ((byte)GossipHintStyle << 8);
+            parts[3] = (byte)ClockSpeed
+                | ((byte)GossipHintStyle << 8)
+                | ((byte)BlastMaskCooldown << 16);
 
             return parts;
         }


### PR DESCRIPTION
What's new:
- Implemented blast mask cooldown modifier as gimmick. 
- Added gui controls (such a nice guy)

Current options:
- Default (310 frames)
- Instant (1 frame)
- Very short (32 frames)
- Short (128 frames)
- Long (512 frames)
- Very Long (1024 frames)