### PR TITLE
Fix: Missing music in the music folder throws an exception

### DIFF
--- a/Utils/SequenceUtils.cs
+++ b/Utils/SequenceUtils.cs
@@ -60,6 +60,14 @@ namespace MMRando.Utils
                     };
 
                     i += 3;
+
+                    // if file doesn't exist, was removed by user, ignore
+                    if (File.Exists(Values.MusicDirectory + targetName) == false)
+                    {
+                        //TODO write debug to the debug log
+                        continue;
+                    }
+
                 };
 
                 if (sourceSequence.MM_seq != 0x18)


### PR DESCRIPTION
Problem: in 1.10.05 if you try to remove randomized music from the folder and try to randomize an exception is thrown and it stops the whole rom randomization

Fix: Checks if the file exists when building the list of sequences we can use for music randomization. If the file doesn't exist, it isn't added to the list, so FileNotFoundException isn't thrown at AudioSeq build-time.

This will allow users who cannot re-compile the compiler to remove music they do not like from the randomizer.