### PR TITLE
Added Feature: Detects zseq files for Music Randomization

### DIFF
--- a/Utils/SequenceUtils.cs
+++ b/Utils/SequenceUtils.cs
@@ -77,7 +77,7 @@ namespace MMRando.Utils
 
                 // test if file has enough delimiters to separate data into name_bank_formats
                 String[] pieces = filename.Split('_');
-                if (pieces.Length < 3 || pieces.Length > 3)
+                if (pieces.Length != 3)
                 {
                     continue;
                 }

--- a/Utils/SequenceUtils.cs
+++ b/Utils/SequenceUtils.cs
@@ -85,7 +85,7 @@ namespace MMRando.Utils
                 var sourceName = filename;
                 var sourceTypeString = pieces[2].Substring(0, pieces[2].Length - 5);
                 var sourceInstrument = Convert.ToInt32(pieces[1], 16);
-                var sourceType = Array.ConvertAll(sourceTypeString.Split(','), int.Parse).ToList();
+                var sourceType = Array.ConvertAll(sourceTypeString.Split('-'), int.Parse).ToList();
 
                 SequenceInfo sourceSequence = new SequenceInfo
                 {

--- a/Utils/SequenceUtils.cs
+++ b/Utils/SequenceUtils.cs
@@ -66,7 +66,37 @@ namespace MMRando.Utils
                 {
                     RomData.SequenceList.Add(sourceSequence);
                 };
-            };
+            }; // end while (i < lines.Length)
+
+            // check if files were added by user to music folder
+            // we're not going to check for non-zseq here until I find an easy way to do that
+            //  Just going to trust users aren't stupid enough to think renaming a mp3 to zseq will work
+            foreach (String filePath in Directory.GetFiles(Values.MusicDirectory, "*.zseq"))
+            {
+                String filename = Path.GetFileName(filePath);
+
+                // test if file has enough delimiters to separate data into name_bank_formats
+                String[] pieces = filename.Split('_');
+                if (pieces.Length < 3 || pieces.Length > 3)
+                {
+                    continue;
+                }
+
+                var sourceName = filename;
+                var sourceTypeString = pieces[2].Substring(0, pieces[2].Length - 5);
+                var sourceInstrument = Convert.ToInt32(pieces[1], 16);
+                var sourceType = Array.ConvertAll(sourceTypeString.Split(','), int.Parse).ToList();
+
+                SequenceInfo sourceSequence = new SequenceInfo
+                {
+                    Name = sourceName,
+                    Type = sourceType,
+                    Instrument = sourceInstrument
+                };
+
+                RomData.SequenceList.Add(sourceSequence);
+            }
+
         }
 
         public static void RebuildAudioSeq(List<SequenceInfo> SequenceList)


### PR DESCRIPTION
Feature: with this piece of code users can add their own zSequence music files to the randomizer's music folder in order for the randomizer to find and use them in randomized music.

The files must:
A) be a zseq format with a .zseq filename
B) have a three part filename, delimited by a single underscore [_], such that:
  1) The first part is a name, a string identifying what the file is
  2) The second part is the Instrument bank (in base 16) that will be used to play the song in MM
  3) The third part is the list of categories the song can be randomized into, delimited by a single dash [-] 

Example filename: smb2-overworld_24_0-1-2-3-4-5-6-7.zseq
where smb2-overworld is the ID, 0x24 is the bank, and the song can be randomized into categories 0,1,2,3,4,5,6 and 7