### PR TITLE
Bypass: MM-only music can cause garbage audio on PJ64 2.4

### DIFF
--- a/Utils/SequenceUtils.cs
+++ b/Utils/SequenceUtils.cs
@@ -171,7 +171,8 @@ namespace MMRando.Utils
                 addr += newentry.Size;
             }
 
-            if (addr > (RomData.MMFileList[4].End - RomData.MMFileList[4].Addr))
+            // if (addr > (RomData.MMFileList[4].End - RomData.MMFileList[4].Addr))
+            if ( true ) // TODO: figure out why leaving the audioseq in its orginal spot causes garbage audio
             {
                 int index = RomUtils.AppendFile(NewAudioSeq);
                 ResourceUtils.ApplyHack(Values.ModsDirectory + "reloc-audio");


### PR DESCRIPTION
This bypass stops randomized music from sounding like snow/whitenoise/garbage in PJ64 2.X by always moving the audioseq file to a later point in the rom.

I don't know yet why this happens, ~maybe it doesn't happen after I convert all my music to 16 byte aligned~, but it seems to work in all N64 emulators I have access too.

Edit: No it's still broken with MM only, my music is irrelevant in that situation. This is still an issue that needs fixing/bypassing.

This is only really an issue with pointerized slots and/or MM only, because those are the only two times the Audioseq is small enough to fit in the old spot. In 1.10.0.5 and earlier, we used DB music, which is often larger than the slots it was replacing, and even with DB pointerizing one song it was still too heavy and the audioseq is always moved.