### PR TITLE
Music rando: sets audioseq to always write to new location

### DIFF
--- a/MMR.Randomizer/Utils/SequenceUtils.cs
+++ b/MMR.Randomizer/Utils/SequenceUtils.cs
@@ -171,19 +171,18 @@ namespace MMR.Randomizer.Utils
                 addr += newentry.Size;
             }
 
-            if (addr > (RomData.MMFileList[4].End - RomData.MMFileList[4].Addr))
-            {
-                int index = RomUtils.AppendFile(NewAudioSeq);
-                ResourceUtils.ApplyHack(Values.ModsDirectory + "reloc-audio");
-                RelocateSeq(index);
-                RomData.MMFileList[4].Data = new byte[0];
-                RomData.MMFileList[4].Cmp_Addr = -1;
-                RomData.MMFileList[4].Cmp_End = -1;
-            }
-            else
-            {
-                RomData.MMFileList[4].Data = NewAudioSeq;
-            }
+            // discovered when MM-only music was fixed, if the audioseq is left in it's old spot
+            // audio quality is garbage, sounds like static
+            //if (addr > (RomData.MMFileList[4].End - RomData.MMFileList[4].Addr))
+            //else
+                //RomData.MMFileList[4].Data = NewAudioSeq;
+
+            int index = RomUtils.AppendFile(NewAudioSeq);
+            ResourceUtils.ApplyHack(Values.ModsDirectory + "reloc-audio");
+            RelocateSeq(index);
+            RomData.MMFileList[4].Data = new byte[0];
+            RomData.MMFileList[4].Cmp_Addr = -1;
+            RomData.MMFileList[4].Cmp_End = -1;
 
             //update pointer table
             f = RomUtils.GetFileIndexForWriting(Addresses.SeqTable);


### PR DESCRIPTION
This fixes an issue where if the audioseq is too small it attempts to write it back to the old audioseq spot, but for some reason the sound gets corrupted and turns to static. 

This wasn't noticed as an issue before it became possible to pointerize songs or use MM-only, because before that it was very rare for the randomized music combinations to be smaller than the original. In 1.10 one song is removed (intro cutscene) but one song is added back in (fairy fountain) and on average the replacement music was larger.