### PR TITLE
Main Form: Replaces the Pop up when a rom finishes 

### DIFF
--- a/MMR.UI/Forms/MainForm.cs
+++ b/MMR.UI/Forms/MainForm.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Windows.Forms;
+using System.Media;
 using MMR.Randomizer.Models;
 using MMR.Randomizer.Utils;
 using MMR.Randomizer.Asm;
@@ -166,8 +167,14 @@ namespace MMR.UI.Forms
 
         private void bgWorker_WorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
         {
-            pProgress.Value = 0;
-            lStatus.Text = "Ready...";
+            if (pProgress.Value < pProgress.Maximum)
+            {
+                lStatus.Text = "Build failed! Ready for another seed...";
+            }
+            else
+            {
+                lStatus.Text = "Build finished! Ready for another seed...";
+            }
             EnableAllControls(true);
             ToggleCheckBoxes();
             TogglePatchSettings(ttOutput.SelectedTab.TabIndex == 0);
@@ -1068,7 +1075,10 @@ namespace MMR.UI.Forms
 
             _settings.InputPatchFilename = null;
 
-            MessageBox.Show("Generation complete!", "Success", MessageBoxButtons.OK, MessageBoxIcon.None);
+            SystemSounds.Asterisk.Play(); // plays audio notification that build is done
+            // TODO replace this with a sound effect from MM
+            //SoundPlayer simpleSound = new SoundPlayer(@"Resources\seed_done.wav");
+            //simpleSound.Play();
         }
 
         private bool ValidateSettingsFile(String[] lines)

--- a/MMR.UI/Forms/MainForm.cs
+++ b/MMR.UI/Forms/MainForm.cs
@@ -1075,10 +1075,10 @@ namespace MMR.UI.Forms
 
             _settings.InputPatchFilename = null;
 
-            SystemSounds.Asterisk.Play(); // plays audio notification that build is done
-            // TODO replace this with a sound effect from MM
-            //SoundPlayer simpleSound = new SoundPlayer(@"Resources\seed_done.wav");
-            //simpleSound.Play();
+            if (File.Exists("SeedDone.wav"))
+                new SoundPlayer("SeedDone.wav").Play();  // specific sfx file
+            else
+                SystemSounds.Asterisk.Play();             // System sound
         }
 
         private bool ValidateSettingsFile(String[] lines)

--- a/MMR.UI/Forms/MainForm.cs
+++ b/MMR.UI/Forms/MainForm.cs
@@ -167,7 +167,11 @@ namespace MMR.UI.Forms
 
         private void bgWorker_WorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
         {
-            if (pProgress.Value < pProgress.Maximum)
+            if ((_settings.GenerateSpoilerLog || _settings.GenerateHTMLLog) && !_settings.GeneratePatch && !_settings.GenerateROM)
+            {
+                lStatus.Text = "Log generated! Ready for another seed...";
+            }
+            else if (pProgress.Value < pProgress.Maximum)
             {
                 lStatus.Text = "Build failed! Ready for another seed...";
             }


### PR DESCRIPTION
Currently the Randomizer opens a "Press OK to continue" popup when it completes generating a new seed. Editing the original randomizer form is impossible until you hunt down this tiny window with your mouse and close it. It's annoying and not necessary, it's old windows mouse-centric design from the 90's when GUI were still something to marvel at as new technology.

Instead, this changes the randomizer to create an audible chime telling you when the rando has finished a seed. In addition, the progress bar is no longer reset, and the text is changed to indicate that the seed has finished and is ready for another render. This serves as a visual indicator of completion that is distinct from the randomizer before the seed is generated, preventing confusion as to whether or not you remembered to start the generation or not.

If the seed fails, it shows an incomplete progress bar.

Edit: the second commit adds the ability to detect a user selected "seed is done" sound effect.