### PR TITLE
Custom instrument set recyling

### DIFF
--- a/MMR.Randomizer/Builder.cs
+++ b/MMR.Randomizer/Builder.cs
@@ -109,9 +109,10 @@ namespace MMR.Randomizer
                             testSeq.SequenceBinaryList.OrderBy(x => random.Next()).ToList();
 
                         // clear the sequence list of sequences we cannot use
-                        testSeq.SequenceBinaryList = testSeq.SequenceBinaryList.FindAll(u => RomData.InstrumentSetList[u.InstrumentSet.BankSlot].Modified == 0
-                                                                                          || (u.InstrumentSet.Hash != 0 
-                                                                                           && u.InstrumentSet.Hash == RomData.InstrumentSetList[u.InstrumentSet.BankSlot].Hash));
+                        testSeq.SequenceBinaryList = testSeq.SequenceBinaryList.FindAll(u => u.InstrumentSet != null 
+                                                                                          && (RomData.InstrumentSetList[u.InstrumentSet.BankSlot].Modified == 0
+                                                                                            || ( u.InstrumentSet.Hash != 0 
+                                                                                              && u.InstrumentSet.Hash == RomData.InstrumentSetList[u.InstrumentSet.BankSlot].Hash)));
                         if (testSeq.SequenceBinaryList.Count == 0) // all removed, song is dead.
                         {
                             // TODO write detection for a song already chosen, that could swap to a bank we can use with this song, to swap both for compatibility

--- a/MMR.Randomizer/Builder.cs
+++ b/MMR.Randomizer/Builder.cs
@@ -1419,19 +1419,19 @@ namespace MMR.Randomizer
             }
             WriteMiscellaneousChanges();
 
-            progressReporter.ReportProgress(72, "Writing cosmetics...");
-            WriteTatlColour(new Random(BitConverter.ToInt32(hash, 0)));
-            WriteTunicColor();
-
-            progressReporter.ReportProgress(73, "Writing music...");
-            WriteAudioSeq(new Random(BitConverter.ToInt32(hash, 0)), outputSettings);
-            WriteMuteMusic();
-
-            progressReporter.ReportProgress(74, "Writing sound effects...");
-            WriteSoundEffects(new Random(BitConverter.ToInt32(hash, 0)));
-
             if (outputSettings.GenerateROM || outputSettings.OutputVC)
             {
+                progressReporter.ReportProgress(72, "Writing cosmetics...");
+                WriteTatlColour(new Random(BitConverter.ToInt32(hash, 0)));
+                WriteTunicColor();
+
+                progressReporter.ReportProgress(73, "Writing music...");
+                WriteAudioSeq(new Random(BitConverter.ToInt32(hash, 0)), outputSettings);
+                WriteMuteMusic();
+
+                progressReporter.ReportProgress(74, "Writing sound effects...");
+                WriteSoundEffects(new Random(BitConverter.ToInt32(hash, 0)));
+
                 progressReporter.ReportProgress(75, "Building ROM...");
 
                 byte[] ROM = RomUtils.BuildROM();

--- a/MMR.Randomizer/Models/Rom/InstrumentSetInfo.cs
+++ b/MMR.Randomizer/Models/Rom/InstrumentSetInfo.cs
@@ -6,7 +6,8 @@ namespace MMR.Randomizer.Models.Rom
         public byte[] BankBinary { get; set; } = null;
         public int BankSlot { get; set; }
         public byte[] BankMetaData { get; set; } = null;
-        public bool Modified = false;
+        public int Modified = 0;
+        public long Hash { get; set; } = 0;
 
     }
 }

--- a/MMR.Randomizer/Utils/SequenceUtils.cs
+++ b/MMR.Randomizer/Utils/SequenceUtils.cs
@@ -392,8 +392,13 @@ namespace MMR.Randomizer.Utils
                             throw new Exception("Reached music write without a song to write");
                         if (SequenceList[j].SequenceBinaryList.Count > 1)
                             WriteOutput("Warning: writing song with multiple sequence/bank combos, selecting first available");
-                        newentry.Size = SequenceList[j].SequenceBinaryList[0].SequenceBinary.Length;
                         newentry.Data = SequenceList[j].SequenceBinaryList[0].SequenceBinary;
+                        // if the sequence is not padded to 16 bytes, the DMA fails
+                        //  music can stop from playing and on hardware it will just straight crash
+                        if (newentry.Data.Length % 0x10 != 0)
+                            newentry.Data = newentry.Data.Concat(new byte[0x10 - (newentry.Data.Length % 0x10)]).ToArray();
+                        newentry.Size = newentry.Data.Length;
+
                         WriteOutput("Slot " + i.ToString("X") + " := " + SequenceList[j].Name + " *");
 
                     }

--- a/MMR.Randomizer/Utils/SequenceUtils.cs
+++ b/MMR.Randomizer/Utils/SequenceUtils.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Diagnostics;
 using System.IO.Compression;
 using MMR.Randomizer.Models.Settings;
+using System.Security.Cryptography;
 
 namespace MMR.Randomizer.Utils
 {
@@ -163,7 +164,7 @@ namespace MMR.Randomizer.Utils
                         BankBinary = input_bank_data,
                         BankMetaData = meta_data,
                         BankSlot = Convert.ToInt32(pieces[1], 16),
-                        Modified = true
+                        Modified = 1
                     };
                 }
 
@@ -203,6 +204,8 @@ namespace MMR.Randomizer.Utils
             //    if the song requires a custom audiobank, the bank and bank meta data are also here
             //  the user should be able to pack the archive with multiple sequences and multiple banks to match,
             //   where the redundancy increases likley hood of a song being able to be placed in a free audiobank slot
+
+            MD5 md5lib = MD5.Create();
 
             foreach (String filePath in Directory.GetFiles(directory, "*.mmrs"))
             {
@@ -265,8 +268,10 @@ namespace MMR.Randomizer.Utils
                                         BankBinary = bank_data,
                                         BankSlot = new_song.Instrument,
                                         BankMetaData = meta_data,
-                                        Modified = true
+                                        Modified = 1,
+                                        Hash = BitConverter.ToInt64(md5lib.ComputeHash(bank_data),0)
                                     };
+                                    Debug.WriteLine("Hash code for bank is " + new_sequence_data.InstrumentSet.Hash.ToString("X"));
                                 }//if requires bank
 
                                 // multiple seq possible, add depending on if first or not

--- a/MMR.Randomizer/Utils/SequenceUtils.cs
+++ b/MMR.Randomizer/Utils/SequenceUtils.cs
@@ -297,7 +297,7 @@ namespace MMR.Randomizer.Utils
         }
 
         // gets passed RomData.SequenceList in Builder.cs::WriteAudioSeq
-        public static void RebuildAudioSeq(List<SequenceInfo> SequenceList, OutputSettings _settings)
+        public static void RebuildAudioSeq(List<SequenceInfo> SequenceList, OutputSettings _settings, bool output_songlog)
         {
             // spoiler log output DEBUG
             StringBuilder log = new StringBuilder();
@@ -369,7 +369,7 @@ namespace MMR.Randomizer.Utils
 
                 if (SequenceList.FindAll(u => u.Replaces == i).Count > 1)
                 {
-                    WriteOutput("Error: Slot " + i.ToString("X") + " has multiple songs pointing at it!");
+                    WriteOutput("Error: Slot " + i.ToString("X2") + " has multiple songs pointing at it!");
                 }
 
                 int p = RomData.PointerizedSequences.FindIndex(u => u.PreviousSlot == i);
@@ -383,13 +383,11 @@ namespace MMR.Randomizer.Utils
                     {
                         newentry.Size = OldSeq[SequenceList[j].MM_seq].Size;
                         newentry.Data = OldSeq[SequenceList[j].MM_seq].Data;
-                        WriteOutput("Slot " + i.ToString("X") + " -> " + SequenceList[j].Name);
+                        WriteOutput("Slot " + i.ToString("X2") + " -> " + SequenceList[j].Name);
 
                     }
-                    else if (SequenceList[j].SequenceBinaryList != null && SequenceList[j].SequenceBinaryList[0] != null)
+                    else if (SequenceList[j].SequenceBinaryList != null && SequenceList[j].SequenceBinaryList.Count > 0)
                     {
-                        if (SequenceList[j].SequenceBinaryList.Count == 0)
-                            throw new Exception("Reached music write without a song to write");
                         if (SequenceList[j].SequenceBinaryList.Count > 1)
                             WriteOutput("Warning: writing song with multiple sequence/bank combos, selecting first available");
                         newentry.Data = SequenceList[j].SequenceBinaryList[0].SequenceBinary;
@@ -399,8 +397,7 @@ namespace MMR.Randomizer.Utils
                             newentry.Data = newentry.Data.Concat(new byte[0x10 - (newentry.Data.Length % 0x10)]).ToArray();
                         newentry.Size = newentry.Data.Length;
 
-                        WriteOutput("Slot " + i.ToString("X") + " := " + SequenceList[j].Name + " *");
-
+                        WriteOutput("Slot " + i.ToString("X2") + " := " + SequenceList[j].Name + " *");
                     }
                     else // non mm, load file and add
                     {
@@ -419,7 +416,7 @@ namespace MMR.Randomizer.Utils
                         }
                         else
                         {
-                            throw new Exception("Music not found as file or built-in resource.");
+                            throw new Exception("Music not found as file or built-in resource. " + SequenceList[j].Filename);
                         }
 
                         // if the sequence is not padded to 16 bytes, the DMA fails
@@ -436,7 +433,7 @@ namespace MMR.Randomizer.Utils
 
                         newentry.Size = data.Length;
                         newentry.Data = data;
-                        WriteOutput("Slot " + i.ToString("X") + " := " + SequenceList[j].Name);
+                        WriteOutput("Slot " + i.ToString("X2") + " := " + SequenceList[j].Name);
 
                     }
                 }
@@ -450,7 +447,6 @@ namespace MMR.Randomizer.Utils
                 // TODO is there not a better way to write this?
                 if (newentry.Data != null)
                 {
-
                     NewAudioSeq = NewAudioSeq.Concat(newentry.Data).ToArray();
                 }
 
@@ -505,22 +501,23 @@ namespace MMR.Randomizer.Utils
 
             }
 
-            // DEBUG spoiler log output
-            String dir = Path.GetDirectoryName(_settings.OutputROMFilename);
-            String path = $"{Path.GetFileNameWithoutExtension(_settings.OutputROMFilename)}";
-            // spoiler log should already be written by the time we reach this far
-            if (File.Exists(Path.Combine(dir, path + "_SpoilerLog.txt")))
-                path += "_SpoilerLog.txt";
-            else // TODO add HTML log compatibility
-                path += "_SongLog.txt";
-
-            using (StreamWriter sw = new StreamWriter(Path.Combine(dir, path), append: true))
+            if (output_songlog)
             {
-                sw.WriteLine(""); // spacer
-                sw.Write(log);
+                // DEBUG spoiler log output
+                String dir = Path.GetDirectoryName(_settings.OutputROMFilename);
+                String path = $"{Path.GetFileNameWithoutExtension(_settings.OutputROMFilename)}";
+                // spoiler log should already be written by the time we reach this far
+                if (File.Exists(Path.Combine(dir, path + "_SpoilerLog.txt")))
+                    path += "_SpoilerLog.txt";
+                else // TODO add HTML log compatibility
+                    path += "_SongLog.txt";
+
+                using (StreamWriter sw = new StreamWriter(Path.Combine(dir, path), append: true))
+                {
+                    sw.WriteLine(""); // spacer
+                    sw.Write(log);
+                }
             }
-
-
         }
 
         /// <summary>

--- a/MMR.Randomizer/Utils/SequenceUtils.cs
+++ b/MMR.Randomizer/Utils/SequenceUtils.cs
@@ -271,7 +271,6 @@ namespace MMR.Randomizer.Utils
                                         Modified = 1,
                                         Hash = BitConverter.ToInt64(md5lib.ComputeHash(bank_data),0)
                                     };
-                                    Debug.WriteLine("Hash code for bank is " + new_sequence_data.InstrumentSet.Hash.ToString("X"));
                                 }//if requires bank
 
                                 // multiple seq possible, add depending on if first or not


### PR DESCRIPTION
In the event two songs need custom instrument sets and they use the same bank in the same slot then both banks will be detected as equal and the second song will be usable.

This allows music writers to make fewer larger instrument sets that they can recycle to allow for fewer audiobank conflicts.

Also fixed sequence padding, which was only padding the old files and not the new ones.