### PR TITLE
UI: Throws a prompt if the user forgot to add a input rom

### DIFF
--- a/MMR.Randomizer/ConfigurationProcessor.cs
+++ b/MMR.Randomizer/ConfigurationProcessor.cs
@@ -9,6 +9,11 @@ namespace MMR.Randomizer
     {
         public static string Process(Configuration configuration, int seed, IProgressReporter progressReporter)
         {
+            if (configuration.OutputSettings.InputROMFilename == "")
+            {
+                return $"Please choose a valid input Majora's Mask (U) .z64 rom";
+            }
+
             var randomizer = new Randomizer(configuration.GameplaySettings, seed);
             RandomizedResult randomized = null;
             if (string.IsNullOrWhiteSpace(configuration.OutputSettings.InputPatchFilename))


### PR DESCRIPTION
Currently in 1.11.0.3 if you attempt to randomize without a input rom the randomizer spins for several seconds before quietly failing, no mention to the cause of the issue is mentioned, and users might even think it succeeded. 

This adds a quick check and prompts the user that they should set a input rom.