### PR TITLE
UI: Explicitly tells users to extract resources folder if it's missing

### DIFF
--- a/MMR.Randomizer/ConfigurationProcessor.cs
+++ b/MMR.Randomizer/ConfigurationProcessor.cs
@@ -1,6 +1,7 @@
 ﻿using MMR.Randomizer.Models;
 using MMR.Randomizer.Models.Settings;
 using MMR.Randomizer.Utils;
+using MMR.Randomizer.Constants;
 using System;
 using System.IO;
 
@@ -10,7 +11,7 @@ namespace MMR.Randomizer
     {
         public static string Process(Configuration configuration, int seed, IProgressReporter progressReporter)
         {
-            if ( !Directory.Exists("Resources"))
+            if (!Directory.Exists(Path.Combine(Values.MainDirectory, "Resources")))
             {
                 return $"Please extract the entire randomizer archive, including the Resources/ folder and subfolders";
             }

--- a/MMR.Randomizer/ConfigurationProcessor.cs
+++ b/MMR.Randomizer/ConfigurationProcessor.cs
@@ -2,6 +2,7 @@
 using MMR.Randomizer.Models.Settings;
 using MMR.Randomizer.Utils;
 using System;
+using System.IO;
 
 namespace MMR.Randomizer
 {
@@ -9,6 +10,11 @@ namespace MMR.Randomizer
     {
         public static string Process(Configuration configuration, int seed, IProgressReporter progressReporter)
         {
+            if ( !Directory.Exists("Resources"))
+            {
+                return $"Please extract the entire randomizer archive, including the Resources/ folder and subfolders";
+            }
+
             var randomizer = new Randomizer(configuration.GameplaySettings, seed);
             RandomizedResult randomized = null;
             if (string.IsNullOrWhiteSpace(configuration.OutputSettings.InputPatchFilename))


### PR DESCRIPTION
Currently if the user extracts only the EXE and attempts to use it, the randomizer throws an error that confuses users 

`Error building ROM: Could not find a part of the path \AppData\Local\Temp\Temp1_MM-Randomizer-v1.10.0.5.zip\Resources\mods\title-screen`

We've all seen this error posted dozens of times in the discord and most developers know to make sure all files are present when they find a missing file error, but to a lot of users this is confusing. 

This new error message checks if the resources folder is present and if it's missing presents them with an error that tells them exactly what is wrong, the old error still exists if a file is corrupted or fails to load, but now we have an error message that hopefully answers the question without further assistance.

There might be a better place to put this error, maybe presenting it at randomizer start instead, but not sure where that is yet.