### PR TITLE
Multithreading CLI: Changes settings and rom file read access to read

### DIFF
--- a/MMR.CLI/Program.cs
+++ b/MMR.CLI/Program.cs
@@ -302,7 +302,7 @@ namespace MMR.CLI
             if (File.Exists(path))
             {
                 Configuration configuration;
-                using (StreamReader Req = new StreamReader(File.Open(path, FileMode.Open)))
+                using (StreamReader Req = new StreamReader(File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read)))
                 {
                     configuration = Configuration.FromJson(Req.ReadToEnd());
                 }

--- a/MMR.Randomizer/Builder.cs
+++ b/MMR.Randomizer/Builder.cs
@@ -305,7 +305,7 @@ namespace MMR.Randomizer
 
             int characterIndex = (int)_randomized.Settings.Character;
 
-            using (var b = new BinaryReader(File.Open(Path.Combine(Values.ObjsDirectory, $"link-{characterIndex}"), FileMode.Open)))
+            using (var b = new BinaryReader(File.OpenRead(Path.Combine(Values.ObjsDirectory, $"link-{characterIndex}"))))
             {
                 var obj = new byte[b.BaseStream.Length];
                 b.Read(obj, 0, obj.Length);
@@ -315,7 +315,7 @@ namespace MMR.Randomizer
 
             if (_randomized.Settings.Character == Character.Kafei)
             {
-                using (var b = new BinaryReader(File.Open(Path.Combine(Values.ObjsDirectory, "kafei"), FileMode.Open)))
+                using (var b = new BinaryReader(File.OpenRead(Path.Combine(Values.ObjsDirectory, "kafei"))))
                 {
                     var obj = new byte[b.BaseStream.Length];
                     b.Read(obj, 0, obj.Length);
@@ -323,7 +323,7 @@ namespace MMR.Randomizer
                     ResourceUtils.ApplyHack(Values.ModsDirectory, "fix-kafei");
                 }
 
-                using (var b = new BinaryReader(File.Open(Path.Combine(Values.ObjsDirectory, "link-mask"), FileMode.Open)))
+                using (var b = new BinaryReader(File.OpenRead(Path.Combine(Values.ObjsDirectory, "link-mask"))))
                 {
                     var obj = new byte[b.BaseStream.Length];
                     b.Read(obj, 0, obj.Length);
@@ -331,7 +331,7 @@ namespace MMR.Randomizer
                     ResourceUtils.ApplyHack(Values.ModsDirectory, "update-kafei-mask-icon");
                 }
 
-                using (var b = new BinaryReader(File.Open(Path.Combine(Values.ObjsDirectory, "gi-link-mask"), FileMode.Open)))
+                using (var b = new BinaryReader(File.OpenRead(Path.Combine(Values.ObjsDirectory, "gi-link-mask"))))
                 {
                     var obj = new byte[b.BaseStream.Length];
                     b.Read(obj, 0, obj.Length);
@@ -1390,7 +1390,7 @@ namespace MMR.Randomizer
 
         public void MakeROM(OutputSettings outputSettings, IProgressReporter progressReporter)
         {
-            using (BinaryReader OldROM = new BinaryReader(File.Open(outputSettings.InputROMFilename, FileMode.Open, FileAccess.Read)))
+            using (BinaryReader OldROM = new BinaryReader(File.OpenRead(outputSettings.InputROMFilename)))
             {
                 RomUtils.ReadFileTable(OldROM);
                 _messageTable.InitializeTable();

--- a/MMR.Randomizer/Utils/RomUtils.cs
+++ b/MMR.Randomizer/Utils/RomUtils.cs
@@ -42,7 +42,7 @@ namespace MMR.Randomizer.Utils
         public static int AddNewFile(string path, string filename)
         {
             byte[] buffer;
-            using (BinaryReader data = new BinaryReader(File.Open(Path.Combine(path, filename), FileMode.Open)))
+            using (BinaryReader data = new BinaryReader(File.OpenRead(Path.Combine(path, filename))))
             {
                 int len = (int)data.BaseStream.Length;
                 buffer = new byte[len];
@@ -107,7 +107,7 @@ namespace MMR.Randomizer.Utils
 
         public static int ByteswapROM(string filename)
         {
-            using (BinaryReader ROM = new BinaryReader(File.Open(filename, FileMode.Open)))
+            using (BinaryReader ROM = new BinaryReader(File.OpenRead(filename)))
             {
                 if (ROM.BaseStream.Length % 4 != 0)
                 {
@@ -454,7 +454,7 @@ namespace MMR.Randomizer.Utils
         public static bool ValidateROM(string FileName)
         {
             bool res = false;
-            using (BinaryReader ROM = new BinaryReader(File.Open(FileName, FileMode.Open, FileAccess.Read, FileShare.Read)))
+            using (BinaryReader ROM = new BinaryReader(File.OpenRead(FileName)))
             {
                 if (ROM.BaseStream.Length == 0x2000000)
                 {

--- a/MMR.Randomizer/Utils/RomUtils.cs
+++ b/MMR.Randomizer/Utils/RomUtils.cs
@@ -454,7 +454,7 @@ namespace MMR.Randomizer.Utils
         public static bool ValidateROM(string FileName)
         {
             bool res = false;
-            using (BinaryReader ROM = new BinaryReader(File.Open(FileName, FileMode.Open, FileAccess.Read)))
+            using (BinaryReader ROM = new BinaryReader(File.Open(FileName, FileMode.Open, FileAccess.Read, FileShare.Read)))
             {
                 if (ROM.BaseStream.Length == 0x2000000)
                 {

--- a/MMR.Randomizer/Utils/SequenceUtils.cs
+++ b/MMR.Randomizer/Utils/SequenceUtils.cs
@@ -132,7 +132,7 @@ namespace MMR.Randomizer.Utils
                 }
 
                 byte[] input_seq_data = null;
-                using (BinaryReader bank_reader = new BinaryReader(File.Open(Path.Combine(directory , filename), FileMode.Open)))
+                using (BinaryReader bank_reader = new BinaryReader(File.OpenRead(Path.Combine(directory , filename))))
                 {
                     input_seq_data = new byte[((int)bank_reader.BaseStream.Length)];
                     bank_reader.Read(input_seq_data, 0, (int)bank_reader.BaseStream.Length);
@@ -146,14 +146,14 @@ namespace MMR.Randomizer.Utils
                     // load the custom bank for this file
                     byte[] input_bank_data = null;
                     String bank_name = filename.Substring(0, filename.LastIndexOf(".zseq")) + ".zbank";
-                    using (BinaryReader bank_reader = new BinaryReader(File.Open(Path.Combine(directory , bank_name), FileMode.Open)))
+                    using (BinaryReader bank_reader = new BinaryReader(File.OpenRead(Path.Combine(directory , bank_name))))
                     {
                         input_bank_data = new byte[((int)bank_reader.BaseStream.Length)];
                         bank_reader.Read(input_bank_data, 0, (int)bank_reader.BaseStream.Length);
                     }
 
                     byte[] meta_data = new byte[8];
-                    using (BinaryReader meta_reader = new BinaryReader(File.Open(Path.Combine(directory , bank_name.Substring(0, bank_name.LastIndexOf(".zbank")) + ".bankmeta"), FileMode.Open)))
+                    using (BinaryReader meta_reader = new BinaryReader(File.OpenRead(Path.Combine(directory , bank_name.Substring(0, bank_name.LastIndexOf(".zbank")) + ".bankmeta"))))
                         meta_reader.Read(meta_data, 0, meta_data.Length);
 
                     pieces[1] = pieces[1].Replace("x", "");
@@ -398,7 +398,7 @@ namespace MMR.Randomizer.Utils
                         byte[] data;
                         if (File.Exists(SequenceList[j].Filename))
                         {
-                            using (var reader = new BinaryReader(File.Open(SequenceList[j].Filename, FileMode.Open)))
+                            using (var reader = new BinaryReader(File.OpenRead(SequenceList[j].Filename)))
                             {
                                 data = new byte[(int)reader.BaseStream.Length];
                                 reader.Read(data, 0, data.Length);


### PR DESCRIPTION
If you try to run CLI with multiple threads some threads break because rando doesn't specify filesharing for the rom and the settings file, but we only need to read these files and windows should allow those files to be read by multiple programs at once, so long as it's specified.