### PR TITLE
Add MessageEntryBuilder

### DIFF
--- a/MMR.Common/Extensions/PrimitiveExtensions.cs
+++ b/MMR.Common/Extensions/PrimitiveExtensions.cs
@@ -1,0 +1,9 @@
+﻿namespace MMR.Common.Extensions
+{
+    public static class PrimitiveExtensions
+    {
+        public static byte LeftByte(this ushort @this) => (byte) (@this >> 8);
+
+        public static byte RightByte(this ushort @this) => (byte) (@this & 0xFF);
+    }
+}

--- a/MMR.Randomizer.Tests/MMR.Randomizer.Tests.csproj
+++ b/MMR.Randomizer.Tests/MMR.Randomizer.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MMR.Randomizer\MMR.Randomizer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/MMR.Randomizer.Tests/Models/Rom/MessageEntryBuilderTests.cs
+++ b/MMR.Randomizer.Tests/Models/Rom/MessageEntryBuilderTests.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using MMR.Randomizer.Models.Rom;
+using NUnit.Framework;
+
+namespace MMR.Randomizer.Tests.Models.Rom
+{
+    public class MessageEntryBuilderTests
+    {
+        private MessageEntry SkulltulaEntry = new MessageEntry
+        {
+            Id = 0x52,
+            Header = new byte[11] {0x02, 0x00, 0x52, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
+            Message =
+                $"\u0017You got a \u0006Swamp Gold Skulltula\u0011Spirit\0!\u0018\u001F\u0000\u0010 This is your \u0001\u000D\u0000 one!\u00BF",
+        };
+
+        [Test]
+        public void HeaderBuilderTest()
+        {
+            var builder = new MessageEntryBuilder.HeaderBuilder();
+
+            builder.FaintBlue().Y(0).Icon(0x52).NextMessage(0xFFFF).RupeeCost(0xFFFF);
+
+            byte[] initialHeaderBytes = SkulltulaEntry.Header;
+            byte[] builderHeaderBytes = builder.Build();
+
+            Assert.That(builderHeaderBytes, Is.EqualTo(initialHeaderBytes));
+        }
+
+        [Test]
+        public void MessageBuilderTest()
+        {
+            var builder = new MessageEntryBuilder.MessageBuilder();
+
+            builder
+                .QuickTextStart().Text("You got a ").StartPinkText().Text("Swamp Gold Skulltula").NewLine()
+                .Text("Spirit").StartWhiteText().Text("!").QuickTextStop().PauseText(0x0010).Text(" This is your ").StartRedText().SkulltulaCount().StartWhiteText().Text(" one!").EndFinalTextBox();
+
+            byte[] initialMessageBytes = Array.ConvertAll(SkulltulaEntry.Message.ToCharArray(), it => (byte) it);
+            byte[] builderMessageBytes = Array.ConvertAll(builder.Build().ToCharArray(), it => (byte) it);
+
+            Assert.That(builderMessageBytes, Is.EqualTo(initialMessageBytes));
+        }
+
+        [Test]
+        public void MessageBuilderEntryTest()
+        {
+            var builder = new MessageEntryBuilder();
+
+            MessageEntry entry = builder
+                .Id(0x52)
+                .Header(it => { it.FaintBlue().Y(0).Icon(0x52).NextMessage(0xFFFF).RupeeCost(0xFFFF); })
+                .Message(it =>
+                {
+                    it
+                        .QuickTextStart().Text("You got a ").StartPinkText().Text("Swamp Gold Skulltula").NewLine()
+                        .Text("Spirit").StartWhiteText().Text("!").QuickTextStop().PauseText(0x0010).Text(" This is your ").StartRedText().SkulltulaCount().StartWhiteText().Text(" one!").EndFinalTextBox();
+                })
+                .Build();
+
+            Assert.IsTrue(entry.Equals(SkulltulaEntry));
+        }
+
+        [Test]
+        public void MessageBuilderDslTest()
+        {
+            var builder = new MessageEntryBuilder();
+
+            MessageEntry entry = builder
+                .Id(0x52)
+                .Header(it => { it.FaintBlue().Y(0).Icon(0x52).NextMessage(0xFFFF).RupeeCost(0xFFFF); })
+                .Message(it =>
+                {
+                    it.QuickText(() =>
+                        {
+                            it
+                                .Text("You got a ")
+                                .Pink(() =>
+                                {
+                                    it
+                                        .Text("Swamp Gold Skulltula")
+                                        .NewLine()
+                                        .Text("Spirit");
+                                })
+                                .White(() => { it.Text("!"); });
+                        })
+                        .PauseText(0x0010)
+                        .Text(" This is your ")
+                        .Red(() => { it.SkulltulaCount(); })
+                        .White(() => { it.Text(" one!"); })
+                        .EndFinalTextBox();
+                })
+                .Build();
+
+            Assert.IsTrue(entry.Equals(SkulltulaEntry));
+        }
+    }
+}

--- a/MMR.Randomizer/Builder.cs
+++ b/MMR.Randomizer/Builder.cs
@@ -1227,18 +1227,62 @@ namespace MMR.Randomizer
             {
                 ResourceUtils.ApplyHack(Values.ModsDirectory, "fix-skulltula-tokens");
 
-                newMessages.Add(new MessageEntry
-                {
-                    Id = 0x51,
-                    Header = new byte[11] { 0x02, 0x00, 0x52, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF },
-                    Message = $"\u0017You got an \u0005Ocean Gold Skulltula\u0011Spirit\0!\u0018\u001F\u0000\u0010 This is your \u0001\u000D\u0000 one!\u00BF",
-                });
-                newMessages.Add(new MessageEntry
-                {
-                    Id = 0x52,
-                    Header = new byte[11] { 0x02, 0x00, 0x52, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF },
-                    Message = $"\u0017You got a \u0006Swamp Gold Skulltula\u0011Spirit\0!\u0018\u001F\u0000\u0010 This is your \u0001\u000D\u0000 one!\u00BF",
-                });
+                MessageEntry oceanSkulltulaEntry = new MessageEntryBuilder()
+                    .Id(0x51)
+                    .Header(it => { it.FaintBlue().Icon(0x52); })
+                    .Message(it =>
+                    {
+                        it
+                            .QuickText(() =>
+                            {
+                                it
+                                    .Text("You got an ")
+                                    .LightBlue(() =>
+                                    {
+                                        it
+                                            .Text("Ocean Gold Skulltula")
+                                            .NewLine()
+                                            .Text("Spirit");
+                                    })
+                                    .White(() => { it.Text("!"); });
+                            })
+                            .PauseText(0x0010)
+                            .Text(" This is your ")
+                            .Red(() => { it.SkulltulaCount(); })
+                            .White(() => { it.Text(" one!"); })
+                            .EndFinalTextBox();
+                    })
+                    .Build();
+                newMessages.Add(oceanSkulltulaEntry);
+
+                MessageEntry swampSkulltulaEntry = new MessageEntryBuilder()
+                    .Id(0x52)
+                    .Header(it => { it.FaintBlue().Icon(0x52); })
+                    .Message(it =>
+                    {
+                        it
+                            .QuickText(() =>
+                            {
+                                it
+                                    .Text("You got a ")
+                                    .Pink(() =>
+                                    {
+                                        it
+                                            .Text("Swamp Gold Skulltula")
+                                            .NewLine()
+                                            .Text("Spirit");
+                                    })
+                                    .White(() => { it.Text("!"); });
+                            })
+                            .PauseText(0x0010)
+                            .Text(" This is your ")
+                            .Red(() => { it.SkulltulaCount(); })
+                            .White(() => { it.Text(" one!"); })
+                            .EndFinalTextBox();
+                    })
+                    .Build();
+
+                newMessages.Add(swampSkulltulaEntry);
             }
 
             if (_randomized.Settings.AddStrayFairies)

--- a/MMR.Randomizer/Models/Rom/MessageEntry.cs
+++ b/MMR.Randomizer/Models/Rom/MessageEntry.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 
 namespace MMR.Randomizer.Models.Rom
 {
@@ -27,5 +28,10 @@ namespace MMR.Randomizer.Models.Rom
             msg.CopyTo(data, Header.Length);
             return data;
         }
+
+        public bool Equals(MessageEntry entry) =>
+            Id == entry.Id &&
+            Header.SequenceEqual(entry.Header) &&
+            Message.Equals(entry.Message);
     }
 }

--- a/MMR.Randomizer/Models/Rom/MessageEntryBuilder.cs
+++ b/MMR.Randomizer/Models/Rom/MessageEntryBuilder.cs
@@ -1,0 +1,352 @@
+﻿using System;
+using MMR.Common.Extensions;
+using MMR.Randomizer.GameObjects;
+
+namespace MMR.Randomizer.Models.Rom
+{
+    public class MessageEntryBuilder
+    {
+        private ushort id;
+        private byte[] header = null;
+        private string message = "";
+
+        public MessageEntryBuilder Id(ushort id)
+        {
+            this.id = id;
+            return this;
+        }
+
+        public MessageEntryBuilder Header(Action<HeaderBuilder> configureHeader)
+        {
+            var headerBuilder = new HeaderBuilder();
+            configureHeader(headerBuilder);
+            header = headerBuilder.Build();
+            return this;
+        }
+
+        public MessageEntryBuilder Message(Action<MessageBuilder> configureMessage)
+        {
+            var messageBuilder = new MessageBuilder();
+            configureMessage(messageBuilder);
+            message = messageBuilder.Build();
+            return this;
+        }
+
+        public MessageEntry Build() => new MessageEntry
+        {
+            Id = id,
+            Header = header,
+            Message = message
+        };
+
+        public class HeaderBuilder
+        {
+            private byte textBoxType = 0x00;
+
+            private byte y = 0x00;
+
+            private byte icon = 0x00;
+
+            private ushort nextMessage = 0xFFFF;
+
+            private ushort rupeeCost = 0xFFFF;
+
+            #region TextBox
+
+            private enum TextBoxTypes
+            {
+                Standard = 0x00,
+                SignPost = 0x01,
+                FaintBlue = 0x02
+            }
+
+            public HeaderBuilder Standard() =>
+                SetTextBoxType(TextBoxTypes.Standard);
+
+            public HeaderBuilder SignPost() =>
+                SetTextBoxType(TextBoxTypes.SignPost);
+
+            public HeaderBuilder FaintBlue() =>
+                SetTextBoxType(TextBoxTypes.FaintBlue);
+
+            private HeaderBuilder SetTextBoxType(TextBoxTypes type)
+            {
+                // TODO (before public api exposure): types are a nibble, so need to & 0x0F, or ensure no enum type is greater than 0x0F
+                textBoxType = (byte) type;
+                return this;
+            }
+
+            #endregion
+
+            #region TextBox Y
+
+            public HeaderBuilder Y(byte y)
+            {
+                this.y = y;
+                return this;
+            }
+
+            #endregion
+
+            #region Icon
+
+            public HeaderBuilder Icon(byte icon)
+            {
+                this.icon = icon;
+                return this;
+            }
+
+            #endregion
+
+            #region Next Message
+
+            /// <summary>
+            /// The message id of the message box that follows this one.
+            /// </summary>
+            /// <param name="nextMessage">the message id of the next message box to show</param>
+            /// <returns></returns>
+            public HeaderBuilder NextMessage(ushort nextMessage)
+            {
+                this.nextMessage = nextMessage;
+                return this;
+            }
+
+            #endregion
+
+            #region Rupee Cost
+
+            public HeaderBuilder RupeeCost(ushort cost)
+            {
+                rupeeCost = cost;
+                return this;
+            }
+
+            #endregion
+
+            public byte[] Build()
+            {
+                return new byte[]
+                {
+                    textBoxType,
+                    y,
+                    icon,
+                    nextMessage.LeftByte(),
+                    nextMessage.RightByte(),
+                    rupeeCost.LeftByte(),
+                    rupeeCost.RightByte(),
+                    0xFF, 0xFF, 0xFF, 0xFF
+                };
+            }
+        }
+
+        public class MessageBuilder
+        {
+            private string message = "";
+
+            /// <summary>
+            /// Appends the quick text start control character (0x17) to the message.
+            /// </summary>
+            /// <returns></returns>
+            public MessageBuilder QuickTextStart() =>
+                Append(0x17);
+
+            /// <summary>
+            /// Appends the quick text stop control character (0x18) to the message.
+            /// </summary>
+            /// <returns></returns>
+            public MessageBuilder QuickTextStop() =>
+                Append(0x18);
+
+            /// <summary>
+            /// Appends the pause delay control character (0x1F) and the pause time (in frames) to the message.
+            /// </summary>
+            /// <param name="pauseFrames"></param>
+            /// <returns></returns>
+            public MessageBuilder PauseText(ushort pauseFrames) =>
+                Append(0x1F).Append(pauseFrames);
+
+
+            /// <summary>
+            /// Appends the end text box control character (0x10) to the message.
+            /// </summary>
+            /// <returns></returns>
+            public MessageBuilder EndTextBox() =>
+                Append(0x10);
+
+            /// <summary>
+            /// Appends the Skulltula count control character (0x0D) to the message.
+            /// <para>
+            /// The game takes care of handling cardinality, like 1st, 2nd, 3rd, 4th, etc.
+            /// It also keeps track of the current Skulltula type (meaning, there are not
+            /// two separate control characters for Ocean count and Swamp count).
+            /// </para>
+            /// <para>
+            /// Multiple occurrences will render multiple times.
+            /// </para>
+            /// </summary>
+            /// <returns></returns>
+            public MessageBuilder SkulltulaCount() =>
+                Append(0x0D);
+
+            /// <summary>
+            /// Appends the end final text box control character (0xBF) to the message.
+            /// This character signals that the text box can be dismissed.
+            /// </summary>
+            /// <returns></returns>
+            public MessageBuilder EndFinalTextBox() =>
+                Append(0xBF);
+
+            /// <summary>
+            /// Appends the new line control character (0x11) to the message.
+            /// </summary>
+            /// <returns></returns>
+            public MessageBuilder NewLine() =>
+                Append(0x11);
+
+            /// <summary>
+            /// Appends the text to the message.
+            /// </summary>
+            /// <para>
+            /// The text color will be the last text color control character appended to the message.
+            /// If no text color has been selected, the default is white.
+            /// </para>
+            /// <param name="text"></param>
+            /// <returns></returns>
+            public MessageBuilder Text(string text) =>
+                Append(text);
+
+            #region Text Colors
+
+            /// <summary>
+            /// Appends the start white text control character (0x00) to the message.
+            /// </summary>
+            /// <returns></returns>
+            public MessageBuilder StartWhiteText() =>
+                Append(TextCommands.ColorWhite);
+
+            /// <summary>
+            /// Appends the start red text control character (0x01) to the message.
+            /// </summary>
+            /// <returns></returns>
+            public MessageBuilder StartRedText() =>
+                Append(TextCommands.ColorRed);
+
+            /// <summary>
+            /// Appends the start light blue text control character (0x05) to the message.
+            /// </summary>
+            /// <para>
+            /// Tatl uses this color at the beginning of her messages.
+            /// </para>
+            /// <returns></returns>
+            public MessageBuilder StartLightBlueText() =>
+                Append(TextCommands.ColorLightBlue);
+
+            /// <summary>
+            /// Appends the start pink text control character (0x06) to the message.
+            /// </summary>
+            /// <returns></returns>
+            public MessageBuilder StartPinkText() =>
+                Append(TextCommands.ColorPink);
+
+            #endregion
+
+            /// <summary>
+            /// Returns the completed message string.
+            /// </summary>
+            /// <returns></returns>
+            public string Build() => message;
+
+            private MessageBuilder Append(string text)
+            {
+                message += text;
+                return this;
+            }
+
+            private MessageBuilder Append(byte value) =>
+                Append((char) value);
+
+            private MessageBuilder Append(char value)
+            {
+                message += value;
+                return this;
+            }
+
+            private MessageBuilder Append(ushort value) =>
+                Append(value.LeftByte()).Append(value.RightByte());
+        }
+    }
+
+    public static class MessageBuilderExtensions
+    {
+        /// <summary>
+        /// Appends the start quick text control character (0x17) to the message, executes the specified action, and
+        /// appends the stop quick text control character(0x18) to the end of the message.
+        /// </summary>
+        /// <param name="this"></param>
+        /// <param name="action"></param>
+        /// <returns></returns>
+        public static MessageEntryBuilder.MessageBuilder QuickText(this MessageEntryBuilder.MessageBuilder @this, Action action)
+        {
+            @this.QuickTextStart();
+            action();
+            @this.QuickTextStop();
+            return @this;
+        }
+
+        #region Color Extensions
+
+        /// <summary>
+        /// Appends the start light blue text control character (0x05) to the message, and executes the specified action.
+        /// </summary>
+        /// <param name="this"></param>
+        /// <param name="action"></param>
+        /// <returns></returns>
+        public static MessageEntryBuilder.MessageBuilder LightBlue(this MessageEntryBuilder.MessageBuilder @this, Action action)
+        {
+            @this.StartLightBlueText();
+            action();
+            return @this;
+        }
+
+        /// <summary>
+        /// Appends the start pink text control character (0x05) to the message, and executes the specified action.
+        /// </summary>
+        /// <param name="this"></param>
+        /// <param name="action"></param>
+        /// <returns></returns>
+        public static MessageEntryBuilder.MessageBuilder Pink(this MessageEntryBuilder.MessageBuilder @this, Action action)
+        {
+            @this.StartPinkText();
+            action();
+            return @this;
+        }
+
+        /// <summary>
+        /// Appends the start white text control character (0x00) to the message, and executes the specified action.
+        /// </summary>
+        /// <param name="this">this message builder</param>
+        /// <param name="action"></param>
+        /// <returns></returns>
+        public static MessageEntryBuilder.MessageBuilder White(this MessageEntryBuilder.MessageBuilder @this, Action action)
+        {
+            @this.StartWhiteText();
+            action();
+            return @this;
+        }
+
+        /// <summary>
+        /// Appends the start red text control character (0x01) to the message, and executes the specified action.
+        /// </summary>
+        /// <param name="this"></param>
+        /// <param name="action"></param>
+        /// <returns></returns>
+        public static MessageEntryBuilder.MessageBuilder Red(this MessageEntryBuilder.MessageBuilder @this, Action action)
+        {
+            @this.StartRedText();
+            action();
+            return @this;
+        }
+
+        #endregion
+    }
+}

--- a/Majora's Mask Randomiser.sln
+++ b/Majora's Mask Randomiser.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MMR.Common", "MMR.Common\MM
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MMR.Common.Tests", "MMR.Common.Tests\MMR.Common.Tests.csproj", "{4DC1E2EE-6DBB-4009-A756-020071FF534E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MMR.Randomizer.Tests", "MMR.Randomizer.Tests\MMR.Randomizer.Tests.csproj", "{74C3DFDA-DE64-4E29-9E97-56ADE2CC8BEB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -71,6 +73,14 @@ Global
 		{4DC1E2EE-6DBB-4009-A756-020071FF534E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{4DC1E2EE-6DBB-4009-A756-020071FF534E}.Release|x86.ActiveCfg = Release|Any CPU
 		{4DC1E2EE-6DBB-4009-A756-020071FF534E}.Release|x86.Build.0 = Release|Any CPU
+		{74C3DFDA-DE64-4E29-9E97-56ADE2CC8BEB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{74C3DFDA-DE64-4E29-9E97-56ADE2CC8BEB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{74C3DFDA-DE64-4E29-9E97-56ADE2CC8BEB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{74C3DFDA-DE64-4E29-9E97-56ADE2CC8BEB}.Debug|x86.Build.0 = Debug|Any CPU
+		{74C3DFDA-DE64-4E29-9E97-56ADE2CC8BEB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{74C3DFDA-DE64-4E29-9E97-56ADE2CC8BEB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{74C3DFDA-DE64-4E29-9E97-56ADE2CC8BEB}.Release|x86.ActiveCfg = Release|Any CPU
+		{74C3DFDA-DE64-4E29-9E97-56ADE2CC8BEB}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This adds (the start of) a fluent interface over the message entry objects, providing an easy to use way for creating message entry objects.

Currently, only the Ocean Gold Skulltula and Swamp Gold Skulltula entries have been changed, as an example of how to use it. It's missing a fair bit of the control characters, and only includes four colors (white, light blue, pink, red), quick text, and text pause, but adding the rest of those should be simple.

Also, wasn't sure of any contributor guidelines, so let me know if anything is out of place.