### PR TITLE
Add option for random Stray Fairy colors

### DIFF
--- a/MMR.Randomizer/Asm/DefaultStrayFairyColors.cs
+++ b/MMR.Randomizer/Asm/DefaultStrayFairyColors.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Drawing;
+
+namespace MMR.Randomizer.Asm
+{
+    internal static class DefaultStrayFairyColors
+    {
+        public static readonly ExtendedObjects.StrayFairyColors ClockTown = new ExtendedObjects.StrayFairyColors
+        {
+            OuterPrimColor = Color.FromArgb(0xFF, 0xA5, 0x00),
+            InnerPrimColor = Color.FromArgb(0xFF, 0xFF, 0xDC),
+            InnerEnvColor = Color.FromArgb(0xFF, 0x80, 0x00),
+        };
+
+        public static readonly ExtendedObjects.StrayFairyColors Woodfall = new ExtendedObjects.StrayFairyColors
+        {
+            OuterPrimColor = Color.FromArgb(0xFF, 0x69, 0xB4),
+            InnerPrimColor = Color.FromArgb(0xFF, 0xDC, 0xFF),
+            InnerEnvColor = Color.FromArgb(0xFF, 0x00, 0x64),
+        };
+
+        public static readonly ExtendedObjects.StrayFairyColors Snowhead = new ExtendedObjects.StrayFairyColors
+        {
+            OuterPrimColor = Color.FromArgb(0x00, 0xC0, 0x00),
+            InnerPrimColor = Color.FromArgb(0xDC, 0xFF, 0xFF),
+            InnerEnvColor = Color.FromArgb(0x00, 0xFF, 0x32),
+        };
+
+        public static readonly ExtendedObjects.StrayFairyColors GreatBay = new ExtendedObjects.StrayFairyColors
+        {
+            OuterPrimColor = Color.FromArgb(0x18, 0x74, 0xCD),
+            InnerPrimColor = Color.FromArgb(0xDC, 0xFF, 0xFF),
+            InnerEnvColor = Color.FromArgb(0x00, 0x64, 0xFF),
+        };
+
+        public static readonly ExtendedObjects.StrayFairyColors StoneTower = new ExtendedObjects.StrayFairyColors
+        {
+            OuterPrimColor = Color.FromArgb(0xFF, 0xFF, 0x00),
+            InnerPrimColor = Color.FromArgb(0xFF, 0xFF, 0xDC),
+            InnerEnvColor = Color.FromArgb(0xFF, 0xFF, 0x00),
+        };
+    }
+
+    internal static class RandomStrayFairColors
+    {
+        private static readonly Random Rng = new Random();
+
+        public static ExtendedObjects.StrayFairyColors Generate()
+        {
+            byte[] randomBytes = new byte[9];
+            Rng.NextBytes(randomBytes);
+
+            return new ExtendedObjects.StrayFairyColors
+            {
+                OuterPrimColor = Color.FromArgb(randomBytes[0], randomBytes[1], randomBytes[2]),
+                InnerPrimColor = Color.FromArgb(randomBytes[3], randomBytes[4], randomBytes[5]),
+                InnerEnvColor = Color.FromArgb(randomBytes[6], randomBytes[7], randomBytes[8]),
+            };
+        }
+    }
+}

--- a/MMR.Randomizer/Asm/ExtendedObjects.cs
+++ b/MMR.Randomizer/Asm/ExtendedObjects.cs
@@ -47,11 +47,12 @@ namespace MMR.Randomizer.Asm
         /// </summary>
         /// <param name="fairies">Whether or not to include Stray Fairy objects</param>
         /// <param name="skulltulas">Whether or not to include Skulltula Token objects</param>
+        /// <param name="randomStrayFairyColors">Whether or not to randomize the Stray Fairy object colors. Does nothing if fairies is false.</param>
         /// <returns>ExtendedObjects</returns>
-        public static ExtendedObjects Create(bool fairies = false, bool skulltulas = false)
+        public static ExtendedObjects Create(bool fairies = false, bool skulltulas = false, bool randomStrayFairyColors = false)
         {
             var result = new ExtendedObjects();
-            result.AddExtendedObjects(fairies, skulltulas);
+            result.AddExtendedObjects(fairies, skulltulas, randomStrayFairyColors);
             return result;
         }
 
@@ -84,7 +85,8 @@ namespace MMR.Randomizer.Asm
         /// </summary>
         /// <param name="fairies">Whether or not to include Stray Fairy objects</param>
         /// <param name="skulltulas">Whether or not to include Skulltula Token objects</param>
-        void AddExtendedObjects(bool fairies = false, bool skulltulas = false)
+        /// <param name="randomStrayFairyColors">Whether or not to randomize the Stray Fairy object colors. Does nothing if fairies is false.</param>
+        void AddExtendedObjects(bool fairies = false, bool skulltulas = false, bool randomStrayFairyColors = false)
         {
             // Add Double Defense
             this.Offsets.Add(AddDoubleDefense());
@@ -104,7 +106,14 @@ namespace MMR.Randomizer.Asm
             // Add Stray Fairies
             if (fairies)
             {
-                AddAllStrayFairies();
+                if (randomStrayFairyColors)
+                {
+                    AddAllRandomStrayFairies();
+                }
+                else
+                {
+                    AddAllStrayFairies();
+                }
                 this.Indexes.Fairies = AdvanceIndex(5);
             }
         }
@@ -136,7 +145,7 @@ namespace MMR.Randomizer.Asm
         /// <summary>
         /// Colors used for Stray Fairy object data.
         /// </summary>
-        struct StrayFairyColors
+        public struct StrayFairyColors
         {
             public Color OuterPrimColor;
             public Color InnerPrimColor;
@@ -153,6 +162,24 @@ namespace MMR.Randomizer.Asm
             this.Offsets.Add(AddSnowheadStrayFairy());
             this.Offsets.Add(AddGreatBayStrayFairy());
             this.Offsets.Add(AddStoneTowerStrayFairy());
+        }
+
+        /// <summary>
+        /// Add all Stray Fairy objects with random colors.
+        /// </summary>
+        void AddAllRandomStrayFairies()
+        {
+            var clockTown = AddRandomStrayFairy();
+            var woodfall = AddRandomStrayFairy();
+            var snowhead = AddRandomStrayFairy();
+            var greatBay = AddRandomStrayFairy();
+            var stoneTower = AddRandomStrayFairy();
+
+            this.Offsets.Add(clockTown);
+            this.Offsets.Add(woodfall);
+            this.Offsets.Add(snowhead);
+            this.Offsets.Add(greatBay);
+            this.Offsets.Add(stoneTower);
         }
 
         /// <summary>
@@ -184,13 +211,7 @@ namespace MMR.Randomizer.Asm
         /// <returns>Offsets</returns>
         (uint, uint) AddClockTownStrayFairy()
         {
-            var colors = new StrayFairyColors
-            {
-                OuterPrimColor = Color.FromArgb(0xFF, 0xA5, 0x00),
-                InnerPrimColor = Color.FromArgb(0xFF, 0xFF, 0xDC),
-                InnerEnvColor = Color.FromArgb(0xFF, 0x80, 0x00),
-            };
-            return AddStrayFairy(colors);
+            return AddStrayFairy(DefaultStrayFairyColors.ClockTown);
         }
 
         /// <summary>
@@ -199,13 +220,7 @@ namespace MMR.Randomizer.Asm
         /// <returns>Offsets</returns>
         (uint, uint) AddWoodfallStrayFairy()
         {
-            var colors = new StrayFairyColors
-            {
-                OuterPrimColor = Color.FromArgb(0xFF, 0x69, 0xB4),
-                InnerPrimColor = Color.FromArgb(0xFF, 0xDC, 0xFF),
-                InnerEnvColor = Color.FromArgb(0xFF, 0x00, 0x64),
-            };
-            return AddStrayFairy(colors);
+            return AddStrayFairy(DefaultStrayFairyColors.Woodfall);
         }
 
         /// <summary>
@@ -214,13 +229,7 @@ namespace MMR.Randomizer.Asm
         /// <returns>Offsets</returns>
         (uint, uint) AddSnowheadStrayFairy()
         {
-            var colors = new StrayFairyColors
-            {
-                OuterPrimColor = Color.FromArgb(0x00, 0xC0, 0x00),
-                InnerPrimColor = Color.FromArgb(0xDC, 0xFF, 0xFF),
-                InnerEnvColor = Color.FromArgb(0x00, 0xFF, 0x32),
-            };
-            return AddStrayFairy(colors);
+            return AddStrayFairy(DefaultStrayFairyColors.Snowhead);
         }
 
         /// <summary>
@@ -229,13 +238,7 @@ namespace MMR.Randomizer.Asm
         /// <returns>Offsets</returns>
         (uint, uint) AddGreatBayStrayFairy()
         {
-            var colors = new StrayFairyColors
-            {
-                OuterPrimColor = Color.FromArgb(0x18, 0x74, 0xCD),
-                InnerPrimColor = Color.FromArgb(0xDC, 0xFF, 0xFF),
-                InnerEnvColor = Color.FromArgb(0x00, 0x64, 0xFF),
-            };
-            return AddStrayFairy(colors);
+            return AddStrayFairy(DefaultStrayFairyColors.GreatBay);
         }
 
         /// <summary>
@@ -244,15 +247,17 @@ namespace MMR.Randomizer.Asm
         /// <returns>Offsets</returns>
         (uint, uint) AddStoneTowerStrayFairy()
         {
-            var colors = new StrayFairyColors
-            {
-                OuterPrimColor = Color.FromArgb(0xFF, 0xFF, 0x00),
-                InnerPrimColor = Color.FromArgb(0xFF, 0xFF, 0xDC),
-                InnerEnvColor = Color.FromArgb(0xFF, 0xFF, 0x00),
-            };
-            return AddStrayFairy(colors);
+            return AddStrayFairy(DefaultStrayFairyColors.StoneTower);
         }
 
+        /// <summary>
+        /// Add an object for Stone Tower Stray Fairies.
+        /// </summary>
+        /// <returns>Offsets</returns>
+        (uint, uint) AddRandomStrayFairy()
+        {
+            return AddStrayFairy(RandomStrayFairColors.Generate());
+        }
         #endregion
 
         #region Skulltula Tokens

--- a/MMR.Randomizer/Builder.cs
+++ b/MMR.Randomizer/Builder.cs
@@ -1526,7 +1526,8 @@ namespace MMR.Randomizer
         {
             var addFairies = _randomized.Settings.AddStrayFairies;
             var addSkulltulas = _randomized.Settings.AddSkulltulaTokens;
-            var extended = _extendedObjects = ExtendedObjects.Create(addFairies, addSkulltulas);
+            var randomStrayFairyColors = _cosmeticSettings.RandomStrayFairyColors;
+            var extended = _extendedObjects = ExtendedObjects.Create(addFairies, addSkulltulas, randomStrayFairyColors);
 
             foreach (var e in RomData.GetItemList.Values)
             {

--- a/MMR.Randomizer/Models/Settings/CosmeticSettings.cs
+++ b/MMR.Randomizer/Models/Settings/CosmeticSettings.cs
@@ -54,6 +54,11 @@ namespace MMR.Randomizer.Models.Settings
         /// </summary>
         public bool EnableNightBGM { get; set; }
 
+        /// <summary>
+        /// Enables stray fairy colors to be randomized.
+        /// </summary>
+        public bool RandomStrayFairyColors { get; set; }
+
         #region Asm Getters / Setters
 
         /// <summary>

--- a/MMR.UI/Forms/MainForm.Designer.cs
+++ b/MMR.UI/Forms/MainForm.Designer.cs
@@ -122,6 +122,7 @@ namespace MMR.UI.Forms
             this.cQuestItemStorage = new System.Windows.Forms.CheckBox();
             this.cCutsc = new System.Windows.Forms.CheckBox();
             this.cNoDowngrades = new System.Windows.Forms.CheckBox();
+            this.cRandomStrayFairyColors = new System.Windows.Forms.CheckBox();
             this.tabGimmicks = new System.Windows.Forms.TabPage();
             this.cByoAmmo = new System.Windows.Forms.CheckBox();
             this.cFDAnywhere = new System.Windows.Forms.CheckBox();
@@ -1119,6 +1120,7 @@ namespace MMR.UI.Forms
             this.groupBox7.Controls.Add(this.cQuestItemStorage);
             this.groupBox7.Controls.Add(this.cCutsc);
             this.groupBox7.Controls.Add(this.cNoDowngrades);
+            this.groupBox7.Controls.Add(this.cRandomStrayFairyColors);
             this.groupBox7.Location = new System.Drawing.Point(373, 6);
             this.groupBox7.Name = "groupBox7";
             this.groupBox7.Size = new System.Drawing.Size(286, 211);
@@ -1315,6 +1317,16 @@ namespace MMR.UI.Forms
             this.cNoDowngrades.UseVisualStyleBackColor = false;
             this.cNoDowngrades.CheckedChanged += new System.EventHandler(this.cNoDowngrades_CheckedChanged);
             // 
+            // cRandomStrayFairyColors
+            //
+            this.cRandomStrayFairyColors.AutoSize = true;
+            this.cRandomStrayFairyColors.Location = new System.Drawing.Point(147, 183);
+            this.cRandomStrayFairyColors.Name = "cRandomStrayFairyColors";
+            this.cRandomStrayFairyColors.Size = new System.Drawing.Size(133, 17);
+            this.cRandomStrayFairyColors.TabIndex = 37;
+            this.cRandomStrayFairyColors.Text = "Random Fairy Colors";
+            this.cRandomStrayFairyColors.CheckedChanged += new System.EventHandler(this.cRandomStrayFairyColors_CheckedChanged);
+            //
             // tabGimmicks
             // 
             this.tabGimmicks.Controls.Add(this.cDeathMoonCrash);
@@ -2181,6 +2193,7 @@ namespace MMR.UI.Forms
         private System.Windows.Forms.Button bToggleTricks;
         private System.Windows.Forms.CheckBox cByoAmmo;
         private System.Windows.Forms.CheckBox cDeathMoonCrash;
+        private System.Windows.Forms.CheckBox cRandomStrayFairyColors;
     }
 }
 

--- a/MMR.UI/Forms/MainForm.cs
+++ b/MMR.UI/Forms/MainForm.cs
@@ -146,6 +146,7 @@ namespace MMR.UI.Forms
             TooltipBuilder.SetTooltip(cEnableNightMusic, "Enables playing daytime Background music during nighttime in the field.\n(Clocktown night music can be weird)");
             TooltipBuilder.SetTooltip(cArrowCycling, "Cycle through arrow types when pressing R while an arrow is out when using the bow.");
             TooltipBuilder.SetTooltip(cCloseCows, "When playing Epona's Song for a group of cows, the closest cow will respond, instead of the default behavior.");
+            TooltipBuilder.SetTooltip(cRandomStrayFairyColors, "Randomizes all Stray Fairy colors.");
         }
 
         /// <summary>
@@ -716,6 +717,11 @@ namespace MMR.UI.Forms
         private void cCloseCows_CheckedChanged(object sender, EventArgs e)
         {
             UpdateSingleSetting(() => _configuration.GameplaySettings.CloseCows = cCloseCows.Checked);
+        }
+
+        private void cRandomStrayFairyColors_CheckedChanged(object sender, EventArgs e)
+        {
+            UpdateSingleSetting(() => _configuration.CosmeticSettings.RandomStrayFairyColors = cRandomStrayFairyColors.Checked);
         }
 
         private void cMode_SelectedIndexChanged(object sender, EventArgs e)


### PR DESCRIPTION
Checkbox added under cosmetic tab to randomize the three colors that make up a Stray Fairy. Method signature changes in ExtendedObjects don't really feel nice, but didn't want to extend ripple farther than necessary.

Also thought of seeding Random instance with _randomizer.Seed from Builder, but didn't want to add another param to ExtendedObjects.Create for the seed.

Next iteration could be a customize button on the cosmetics tab to select which fairies get randomized, maybe color picker, but didn't want to make a ton of Form changes to make this work.