### PR TITLE
Main form: right clicking the randomize button for fast reroll

### DIFF
--- a/MMR.Randomizer/Models/Settings/OutputSettings.cs
+++ b/MMR.Randomizer/Models/Settings/OutputSettings.cs
@@ -27,7 +27,7 @@ namespace MMR.Randomizer.Models.Settings
         [JsonIgnore]
         public string InputPatchFilename { get; set; }
 
-        [JsonIgnore]
+        //[JsonIgnore] // I want this for my right click, so that I can change directories
         public string OutputROMFilename { get; set; }
 
         /// <summary>

--- a/MMR.UI/Forms/MainForm.Designer.cs
+++ b/MMR.UI/Forms/MainForm.Designer.cs
@@ -1676,7 +1676,7 @@ namespace MMR.UI.Forms
             this.bRandomise.TabIndex = 5;
             this.bRandomise.Text = "Randomize";
             this.bRandomise.UseVisualStyleBackColor = true;
-            this.bRandomise.Click += new System.EventHandler(this.bRandomise_Click);
+            this.bRandomise.MouseDown += new System.Windows.Forms.MouseEventHandler(this.bRandomise_MouseDown);
             // 
             // saveWad
             // 


### PR DESCRIPTION
Right clicking the generate button will instantly roll a new seed with the default filename in the same location as the last seed, unless its the first generation, then it puts it in the base MMR folder.

Very handy for entrando when you just want a quick reattempt but don't want to go through the effort of setting up CLI to find a seed.

This is a hack. I don't like that it's hidden behavior that the user has to find by accident or already know its there, I don't like that the settings.json has to have another path that can leak additional private data, but I'm still offering it as a contribution if it's wanted.