### PR TITLE
Add cosmetics patch feature

### DIFF
--- a/MMR.CLI/Program.cs
+++ b/MMR.CLI/Program.cs
@@ -462,6 +462,7 @@ namespace MMR.CLI
                 seed = new Random().Next();
             }
 
+
             var outputArg = argsDictionary.GetValueOrDefault("-output");
             if (outputArg != null)
             {

--- a/MMR.CLI/Program.cs
+++ b/MMR.CLI/Program.cs
@@ -1,4 +1,4 @@
-﻿using MMR.Randomizer.Models.Settings;
+using MMR.Randomizer.Models.Settings;
 using MMR.Randomizer.Models;
 using MMR.Randomizer;
 using MMR.Randomizer.GameObjects;
@@ -444,6 +444,7 @@ namespace MMR.CLI
 
             configuration.OutputSettings.InputPatchFilename = argsDictionary.GetValueOrDefault("-inputpatch")?.SingleOrDefault();
             configuration.OutputSettings.GeneratePatch |= argsDictionary.ContainsKey("-outputpatch");
+            configuration.OutputSettings.GenerateCosmeticsPatch |= argsDictionary.ContainsKey("-cosmeticspatch");
             configuration.OutputSettings.GenerateSpoilerLog |= argsDictionary.ContainsKey("-spoiler");
             configuration.OutputSettings.GenerateHTMLLog |= argsDictionary.ContainsKey("-html");
             configuration.OutputSettings.GenerateROM |= argsDictionary.ContainsKey("-rom");
@@ -460,7 +461,6 @@ namespace MMR.CLI
             {
                 seed = new Random().Next();
             }
-
 
             var outputArg = argsDictionary.GetValueOrDefault("-output");
             if (outputArg != null)

--- a/MMR.Randomizer/ConfigurationProcessor.cs
+++ b/MMR.Randomizer/ConfigurationProcessor.cs
@@ -39,7 +39,7 @@ namespace MMR.Randomizer
                 }
             }
 
-            if (configuration.OutputSettings.GenerateROM || configuration.OutputSettings.OutputVC || configuration.OutputSettings.GeneratePatch)
+            if (configuration.OutputSettings.GenerateROM || configuration.OutputSettings.OutputVC || configuration.OutputSettings.GeneratePatch || configuration.OutputSettings.GenerateCosmeticsPatch)
             {
                 if (!RomUtils.ValidateROM(configuration.OutputSettings.InputROMFilename))
                 {

--- a/MMR.Randomizer/Models/Settings/OutputSettings.cs
+++ b/MMR.Randomizer/Models/Settings/OutputSettings.cs
@@ -67,13 +67,20 @@ namespace MMR.Randomizer.Models.Settings
         [Description("Output a patch file that can be applied using the Patch settings tab to reproduce the same ROM.\nPatch file includes all settings except Tunic and Tatl color.")]
         public bool GeneratePatch { get; set; }
 
+        /// <summary>
+        /// Generate cosmetics patch file
+        /// </summary>
+        [SettingName("Cosmetics Patch .mmr")]
+        [Description("Output a cosmetics patch file.")]
+        public bool GenerateCosmeticsPatch { get; set; }
+
         public string Validate()
         {
-            if (!GenerateROM && !OutputVC && (InputPatchFilename != null || (!GeneratePatch && !GenerateSpoilerLog && !GenerateHTMLLog)))
+            if (!GenerateROM && !OutputVC && ((InputPatchFilename != null && !GenerateCosmeticsPatch) || (!GeneratePatch && !GenerateCosmeticsPatch && !GenerateSpoilerLog && !GenerateHTMLLog)))
             {
                 return "No output selected.";
             }
-            if ((GenerateROM || GeneratePatch || OutputVC) && !File.Exists(InputROMFilename))
+            if ((GenerateROM || GeneratePatch || GenerateCosmeticsPatch || OutputVC) && !File.Exists(InputROMFilename))
             {
                 return "Input ROM not found, cannot generate output.";
             }


### PR DESCRIPTION
This is for the upcoming web patcher. This might be the wrong way to go about it, but it works well (so far). WriteAudioSeq step is skipped for now as this makes SequenceUtils.UpdateBankInstrumentPointers mandatory during BuildROM() which currently can't be handled on the web (a different music rando implementation needs to be added for it). Storing actual music data in patch files is undesirable anyway due to the high chance it could contain copyrighted material