### PR TITLE
Sfx:Fixed Kusa2 burrow sfx crash, deku king princess bounce sfx addre…

### DIFF
--- a/MMR.Randomizer/Models/SoundEffects/SoundEffect.cs
+++ b/MMR.Randomizer/Models/SoundEffects/SoundEffect.cs
@@ -1262,7 +1262,7 @@ namespace MMR.Randomizer.Models.SoundEffects
         //[Tags(Long)]
         //UnknownBugSfx = 0x31F2,
 
-        [Replacable(0xEC618A)] // NA_SE_EN_KINGNUTS_DAMAGE
+        [Replacable(0xEBCBBA)] // NA_SE_EN_KINGNUTS_DAMAGE
         [ReplacableByTags(Long, Short)]
         [Tags(Long)]
         DekuKingBounce = 0x31F6, // princess attack


### PR DESCRIPTION
…ss offset was wrong, must have used DNK instead of DNQ by accident