### PR TITLE
feat(web): restructure settings placement in web gui based on feedback

### DIFF
--- a/MMR.Web.Config/inputFiles/settings_mapping.json
+++ b/MMR.Web.Config/inputFiles/settings_mapping.json
@@ -70,9 +70,10 @@
           "settings": [
             "GameplaySettings.LogicMode",
             "GameplaySettings.UserLogicFileName",
-            "GameplaySettings.ItemPlacement",
-            "Web.RandomStartingItemGroups",
-            "GameplaySettings.RandomStartingItemGroups"
+            "GameplaySettings.VictoryMode",
+            "GameplaySettings.PriceMode",
+            "GameplaySettings.BossRemainsMode",
+            "GameplaySettings.RequiredBossRemains"
           ]
         },
         {
@@ -124,10 +125,10 @@
           "text": "Shuffling",
           "row_span": [ 4, 6, 6 ],
           "settings": [
+            "GameplaySettings.ItemPlacement",
+            "Web.RandomStartingItemGroups",
+            "GameplaySettings.RandomStartingItemGroups",
             "GameplaySettings.EntranceMode",
-            "GameplaySettings.VictoryMode",
-            "GameplaySettings.PriceMode",
-            "GameplaySettings.BossRemainsMode",
             "GameplaySettings.BossKeyMode",
             "GameplaySettings.SmallKeyMode",
             "GameplaySettings.StrayFairyMode",
@@ -233,21 +234,6 @@
       "hide_when_disabled": true,
       "sections": [
         {
-          "name": "speedup_section",
-          "text": "Speed Ups",
-          "row_span": [ 1, 1, 1 ],
-          "settings": [
-            "GameplaySettings.SpeedupDampe",
-            "GameplaySettings.SpeedupLabFish",
-            "GameplaySettings.SpeedupBank",
-            "GameplaySettings.SpeedupBeavers",
-            "GameplaySettings.SpeedupDogRace",
-            "GameplaySettings.DoubleArcheryRewards",
-            "GameplaySettings.SpeedupBabyCuccos",
-            "GameplaySettings.RequiredZoraEggs"
-          ]
-        },
-        {
           "name": "hints_section",
           "text": "Hints",
           "row_span": [ 1, 1, 1 ],
@@ -322,15 +308,31 @@
       ]
     },
     {
-      "name": "shorten_cutscenes_tab",
-      "text": "Shorten Cutscenes",
+      "name": "speedups_tab",
+      "text": "Speedups",
       "app_type": [ "generator" ],
       "hide_when_disabled": true,
       "sections": [
         {
-          "name": "main_section",
-          "text": "",
-          "col_span": 4,
+          "name": "speedup_section",
+          "text": "Speed Ups",
+          "col_span": 2,
+          "row_span": [ 2, 2, 2 ],
+          "settings": [
+            "GameplaySettings.SpeedupDampe",
+            "GameplaySettings.SpeedupLabFish",
+            "GameplaySettings.SpeedupBank",
+            "GameplaySettings.SpeedupBeavers",
+            "GameplaySettings.SpeedupDogRace",
+            "GameplaySettings.DoubleArcheryRewards",
+            "GameplaySettings.SpeedupBabyCuccos",
+            "GameplaySettings.RequiredZoraEggs"
+          ]
+        },
+        {
+          "name": "Shorten Cutscenes",
+          "text": "Shorten Cutscenes",
+          "col_span": 2,
           "row_span": [ 2, 2, 2 ],
           "settings": [
             "GameplaySettings.ShortenCutsceneSettings.General",

--- a/MMR.Web.UI/package.json
+++ b/MMR.Web.UI/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mmr-electron-gui",
   "description": "GUI for Majora's Mask Randomizer",
-  "version": "1.16.0-12",
+  "version": "2.0.0-0",
   "homepage": "https://www.mmrandomizer.com",
   "author": "ZeldaSpeedRuns <zsrstaff@gmail.com>",
   "main": "electron/dist/main.js",


### PR DESCRIPTION
Moves Victory / Prize Mode and adjacent settings to the main settings, item pllacement  and random starting item groups to shuffling, and combines speedups and shorten cutscenes into a tab.

Cleaner this way and more focus on important settings, as suggested by revven