### PR TITLE
[Web] Fix pointerized slot JSON output and include stack trace for easier bug tracking

### DIFF
--- a/MMR.Randomizer/Builder.cs
+++ b/MMR.Randomizer/Builder.cs
@@ -6988,7 +6988,15 @@ namespace MMR.Randomizer
                     foreach (var seq in RomData.PointerizedSequences)
                     {
                         var substituteSeq = gameSequences.Find(u => u.Replaces == seq.Replaces);
-                        pointerizedSequences.Add(seq.Name, substituteSeq != null ? substituteSeq.Name : seq.Replaces.ToString());
+                        string seqName = seq.Name;
+
+                        if (seqName.Length < 1)
+                        {
+                            var originalSeq = gameSequences.Find(u => u.Replaces == seq.PreviousSlot);
+                            seqName = originalSeq.Name;
+                        }
+
+                        pointerizedSequences.Add(seqName, substituteSeq != null ? substituteSeq.Name : seq.Replaces.ToString());
                     }
                     File.WriteAllText(Path.Combine(directory, filename + "_RandomizedMusicPointerizedSeqs.json"), JsonSerializer.Serialize(pointerizedSequences));
 

--- a/MMR.Randomizer/ConfigurationProcessor.cs
+++ b/MMR.Randomizer/ConfigurationProcessor.cs
@@ -79,7 +79,7 @@ namespace MMR.Randomizer
                 catch (Exception ex)
                 {
                     string nl = Environment.NewLine;
-                    return $"Error building ROM: {ex.Message}{nl}{nl}Please contact the development team and provide them more information";
+                    return $"Error building ROM: {ex.Message} {ex.StackTrace} {nl}{nl}Please contact the development team and provide them more information";
                 }
 
                 Debug.WriteLine($" seed build time : [{((DateTime.Now).Subtract(startTime).TotalMilliseconds).ToString()} (ms)]");


### PR DESCRIPTION
Fixes the pointerized slot JSON output by properly resolving empty named slots. This only occurs when specific settings are enabled or the music pool is exhausted. 

Furthermore the exception stack trace is now included in error logs for easier bug tracking on the server