### PR TITLE
fix: random settings item pool not propagating

### DIFF
--- a/MMR.Web.Config/inputFiles/settings_mapping.json
+++ b/MMR.Web.Config/inputFiles/settings_mapping.json
@@ -126,7 +126,6 @@
           "row_span": [ 4, 6, 6 ],
           "settings": [
             "GameplaySettings.ItemPlacement",
-            "GameplaySettings.RandomStartingItemGroups",
             "GameplaySettings.EnemyMode",
             "GameplaySettings.EntranceMode",
             "GameplaySettings.BossKeyMode",
@@ -144,7 +143,8 @@
             "GameplaySettings.RandomizeGibdoRequirements",
             "GameplaySettings.AddSongs",
             "GameplaySettings.StartingItemMode",
-            "Web.RandomStartingItemGroups"
+            "Web.RandomStartingItemGroups",
+            "GameplaySettings.RandomStartingItemGroups"
           ]
         }
       ]


### PR DESCRIPTION
Web Setting can't fetch the item list from C# setting unless they are in the same section...