### PR TITLE
[GUI] Block the user from accidentally trying to export default presets

### DIFF
--- a/MMR.Web.UI/src/app/components/guiSettingsElement/guiSettingsElement.ts
+++ b/MMR.Web.UI/src/app/components/guiSettingsElement/guiSettingsElement.ts
@@ -252,10 +252,12 @@ export class GUISettingsElement implements OnInit {
       return;
     }
 
-    if (("isNewPreset" in targetPreset) && targetPreset.isNewPreset == true) {
+    if ((("isNewPreset" in targetPreset) && targetPreset.isNewPreset == true) || (("isDefaultPreset" in targetPreset) && targetPreset.isDefaultPreset == true)) {
+
       this.dialogService.open(DialogWindowComponent, {
-        autoFocus: true, closeOnBackdropClick: true, closeOnEsc: true, hasBackdrop: true, hasScroll: false, context: { dialogHeader: "Warning", dialogMessage: "You need to save this custom preset first." }
+        autoFocus: true, closeOnBackdropClick: true, closeOnEsc: true, hasBackdrop: true, hasScroll: false, context: { dialogHeader: "Warning", dialogMessage: "System presets can not be exported!" }
       });
+
       return;
     }
 


### PR DESCRIPTION
This hardens the Export preset button a bit more to display an error instead of allowing the user to export a broken/empty default settings preset